### PR TITLE
[WIP] Use docker image for Production.

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -6,10 +6,8 @@ services:
     command: "/bin/bash -c 'yarn install && yarn build && yarn start'"
     restart: always
   gitea:
+    image: docker.pkg.github.com/kitspace/gitea/gitea-image:v1.7.4
     restart: always
-    build:
-      context: gitea/
-      dockerfile: Dockerfile
   postgres:
     restart: always
   nginx:


### PR DESCRIPTION
Don't merge; it will break the staging server as all patching done to Gitea to fit our needs isn't on the master yet

- Instead of relying on git submodule for production use prebuilt docker image of kitspace/gitea[master]