### PR TITLE
Migrate from SSG to SSR

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     ports:
       - '1234:3000'
     environment:
-      - 'NODE_ENV=production'
       - 'KITSPACE_GITEA_URL=${KITSPACE_SCHEME}://gitea.${KITSPACE_DOMAIN}${KITSPACE_EXTERNAL_PORT}'
       - 'KITSPACE_PROCESSOR_URL=${KITSPACE_SCHEME}://processor.${KITSPACE_DOMAIN}${KITSPACE_EXTERNAL_PORT}'
       - 'INDEX_ISR_INTERVAL=${INDEX_ISR_INTERVAL}'
@@ -20,12 +19,12 @@ services:
       - ./frontend:/app
       - /app/node_modules
       - /etc/hosts:/etc/hosts
-    command: /bin/sh --verbose -c "yarn build && yarn start"
+    command: /bin/sh --verbose -c "yarn build && yarn dev"
 
   gitea:
     build:
       context: gitea
-      dockerfile: Dockerfile
+      dockerfile: Dockerfile.gitea.dev
     environment:
       - ROOT_URL=${KITSPACE_SCHEME}://gitea.${KITSPACE_DOMAIN}${KITSPACE_EXTERNAL_PORT}/
       - USER_UID=1000
@@ -45,7 +44,7 @@ services:
       - '2222:22'
     depends_on:
       - postgres
-#    command: /bin/bash --verbose -c "cd /go/src/code.gitea.io/gitea/ && make backend && cp gitea /app/gitea/ && /usr/bin/entrypoint"
+    command: /bin/bash --verbose -c "cd /go/src/code.gitea.io/gitea/ && make backend && cp gitea /app/gitea/ && /usr/bin/entrypoint"
 
   postgres:
     image: postgres:9.6

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "file-selector": "^0.2.4",
     "joi": "^17.2.1",
     "lodash": "^4.17.20",
+    "morgan": "^1.10.0",
     "next": "^10.0.5",
     "node-sass": "^4.13.0",
     "raw-loader": "^4.0.0",

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -13,9 +13,8 @@ const nextHandler = app.getRequestHandler()
 app.prepare().then(() => {
   const server = express()
 
-
   if (dev) {
-  server.use(morgan('dev'))
+    server.use(morgan('dev'))
   } else {
     server.use(morgan('tiny'))
   }

--- a/frontend/server.js
+++ b/frontend/server.js
@@ -1,4 +1,5 @@
 const express = require('express')
+const morgan = require('morgan')
 const next = require('next')
 const conf = require('./next.config.js')
 const bodyParser = require('body-parser')
@@ -12,11 +13,11 @@ const nextHandler = app.getRequestHandler()
 app.prepare().then(() => {
   const server = express()
 
+
   if (dev) {
-    server.use(function (req, res, next) {
-      console.log('%s %s', req.method, req.url)
-      next()
-    })
+  server.use(morgan('dev'))
+  } else {
+    server.use(morgan('tiny'))
   }
 
   server.all('/_next/*', nextHandler)

--- a/frontend/src/hooks/Gitea.js
+++ b/frontend/src/hooks/Gitea.js
@@ -126,15 +126,11 @@ export const useUserRepos = (username, swrOpts = {}) => {
  * @returns {{isLoading: boolean, isError: boolean, files: Object[], mutate: function}}
  */
 export const useDefaultBranchFiles = (repo, swrOpts = {}) => {
-  const { repo: repoDetails } = useRepo(repo, swrOpts)
+  const endpoint = `${giteaApiUrl}/repos/${repo}/contents`
 
   // Dependent data if: swr won't fetch if `repoDetails.default_branch` returns a falsy value.
   // See https://swr.vercel.app/docs/conditional-fetching
-  const { data, error, mutate } = useSWR(
-    () => `${giteaApiUrl}/repos/${repo}/contents?ref=` + repoDetails.default_branch,
-    fetcher,
-    swrOpts,
-  )
+  const { data, error, mutate } = useSWR(() => endpoint, fetcher, swrOpts)
 
   return {
     files: data || [],

--- a/frontend/src/pages/1-click-bom.js
+++ b/frontend/src/pages/1-click-bom.js
@@ -3,15 +3,7 @@ import Link from 'next/link'
 
 import { Page } from '@components/Page'
 
-// Explicitly mark as static.
-// Due to using `getInitialProps` in `_app.js` pages that can be statically built aren't.
-export const getStaticProps = () => {
-  return {
-    props: {},
-  }
-}
-
-export default function OneClickBom() {
+const OneClickBom = () => {
   return (
     <Page>
       <p style={{ textAlign: 'center', minHeight: 86 }}>
@@ -43,3 +35,5 @@ export default function OneClickBom() {
     </Page>
   )
 }
+
+export default OneClickBom

--- a/frontend/src/pages/bom-builder.js
+++ b/frontend/src/pages/bom-builder.js
@@ -3,15 +3,7 @@ import Link from 'next/link'
 
 import { Page } from '@components/Page'
 
-// Explicitly mark as static.
-// Due to using `getInitialProps` in `_app.js` pages that can be statically built aren't.
-export const getStaticProps = () => {
-  return {
-    props: {},
-  }
-}
-
-export default function BomBuilder() {
+const BomBuilder = () => {
   return (
     <Page title="BOM Builder">
       <h1 id="the-kitspace-bom-builder">The Kitspace BOM Builder</h1>
@@ -57,3 +49,5 @@ export default function BomBuilder() {
     </Page>
   )
 }
+
+export default BomBuilder

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -6,16 +6,13 @@ import { AuthContext } from '@contexts/AuthContext'
 import { getAllRepos } from '@utils/giteaApi'
 import { useAllRepos } from '@hooks/Gitea'
 
-export const getStaticProps = async () => {
+export const getServerSideProps = async () => {
   const repos = await getAllRepos()
 
   return {
     props: {
       repos,
     },
-    // Regenerate the static version each hour.
-    // Even If there was an update `useAllRepos` will grab the latest update on mount.
-    revalidate: Number(process.env.INDEX_ISR_INTERVAL) || 3600,
   }
 }
 

--- a/frontend/src/pages/projects/[user].js
+++ b/frontend/src/pages/projects/[user].js
@@ -18,10 +18,9 @@ export const getServerSideProps = async ({ params, req }) => {
         permanent: true,
       },
     }
-  } else if (isEmpty(userRepos) && !(await userNotFound)) {
-    return {
-      notFound: true,
-    }
+    // If the repos are empty check if the user exists
+  } else if (isEmpty(userRepos) && !(await userExists(params.user))) {
+    return { notFound: true }
   } else {
     return {
       props: {
@@ -33,7 +32,9 @@ export const getServerSideProps = async ({ params, req }) => {
 }
 
 const User = ({ userRepos, username }) => {
-  const { repos: projects } = useUserRepos(username, { initialData: userRepos })
+  const { repos: projects } = useUserRepos(username, {
+    initialData: userRepos,
+  })
 
   const projectsList = projects?.map(p => {
     const lastUpdateDate = new Date(p.updated_at)

--- a/frontend/src/pages/projects/[user].js
+++ b/frontend/src/pages/projects/[user].js
@@ -1,49 +1,39 @@
-import React, { useEffect, useContext } from 'react'
-import { useRouter } from 'next/router'
-import _ from 'lodash'
+import React from 'react'
 import { List } from 'semantic-ui-react'
+import { isEmpty } from 'lodash'
 
 import { Page } from '@components/Page'
-import { AuthContext } from '@contexts/AuthContext'
-import { getAllRepos, getUserRepos } from '@utils/giteaApi'
+import { getUserRepos, userExists } from '@utils/giteaApi'
 import styles from './mine.module.scss'
 import { useUserRepos } from '@hooks/Gitea'
 
-export const getStaticPaths = async () => {
-  const allRepos = await getAllRepos()
-  // Fetch all the repos and get the unique usernames from it
-  const paths =
-    _.uniq(allRepos?.map(p => ({ params: { user: p.owner.login } }))) || []
-
-  return { paths, fallback: true }
-}
-
-export const getStaticProps = async ({ params }) => {
+export const getServerSideProps = async ({ params, req }) => {
   const userRepos = await getUserRepos(params.user)
+  const username = req.session?.user?.username
 
-  return {
-    props: {
-      userRepos,
-      username: params.user,
-    },
-    // Regenerate the static version each day.
-    // Even If there was an update `useUserRepos` will grab the latest update on mount.
-    revalidate: Number(process.env.USER_ISR_INTERVAL) || 86400,
+  if (username === params.user) {
+    return {
+      redirect: {
+        destination: '/projects/mine',
+        permanent: true,
+      },
+    }
+  } else if (isEmpty(userRepos) && !(await userNotFound)) {
+    return {
+      notFound: true,
+    }
+  } else {
+    return {
+      props: {
+        userRepos,
+        username: params.user,
+      },
+    }
   }
 }
 
 const User = ({ userRepos, username }) => {
-  const { user } = useContext(AuthContext)
-  const { replace } = useRouter()
-
   const { repos: projects } = useUserRepos(username, { initialData: userRepos })
-
-  useEffect(() => {
-    // Redirect the user to `projects/mine` on accessing `project/{their username}` page.
-    if (username === user?.login) {
-      replace('/projects/mine')
-    }
-  }, [user])
 
   const projectsList = projects?.map(p => {
     const lastUpdateDate = new Date(p.updated_at)

--- a/frontend/src/pages/projects/mine.js
+++ b/frontend/src/pages/projects/mine.js
@@ -7,14 +7,26 @@ import { Page } from '@components/Page'
 import { AuthContext } from '@contexts/AuthContext'
 import styles from './mine.module.scss'
 import { useUserRepos } from '@hooks/Gitea'
+import { getUserRepos } from '@utils/giteaApi'
 
 const DeleteModal = dynamic(() => import('@components/DeleteProjectModal'))
 
-const Mine = () => {
+export const getServerSideProps = async ({ req }) => {
+  const { username } = req.session.user
+  const userRepos = await getUserRepos(username)
+
+  return {
+    props: { userRepos, username },
+  }
+}
+
+const Mine = ({ userRepos }) => {
   const { user } = useContext(AuthContext)
   const { push } = useRouter()
 
-  const { repos: projects, isLoading, mutate } = useUserRepos(user?.username)
+  const { repos: projects, isLoading, mutate } = useUserRepos(user?.username, {
+    initialData: userRepos,
+  })
 
   if (isLoading || !user) {
     return (

--- a/frontend/src/pages/projects/new.js
+++ b/frontend/src/pages/projects/new.js
@@ -25,14 +25,6 @@ import useForm from '@hooks/useForm'
 import { ExistingProjectFromModel } from '@models/ExistingProjectForm'
 import { SyncRepoFromModel } from '@models/SyncRepoForm'
 
-// Explicitly mark as static.
-// Due to using `getInitialProps` in `_app.js` pages that can be statically built aren't.
-export const getStaticProps = () => {
-  return {
-    props: {},
-  }
-}
-
 const New = () => {
   const { csrf, user } = useContext(AuthContext)
   const isBigScreen = useMediaPredicate('(min-width: 1200px)')

--- a/frontend/src/pages/projects/update/[user]/[projectName].js
+++ b/frontend/src/pages/projects/update/[user]/[projectName].js
@@ -54,12 +54,8 @@ export const getServerSideProps = async ({ params, query }) => {
   }
 }
 
-<<<<<<< HEAD
-  const { repo: project, isLoading } = useRepo(fullName)
-=======
 const UpdateProject = ({ repo, repoFiles, isSynced, user, projectName, isNew }) => {
   const fullName = `${user}/${projectName}`
->>>>>>> 73b4d1e (SSR project update page.)
 
   const { repo: project, isLoading, isError } = useRepo(fullName, {
     initialData: repo,

--- a/frontend/src/utils/giteaApi.js
+++ b/frontend/src/utils/giteaApi.js
@@ -182,6 +182,23 @@ export const repoExists = async fullname => {
 }
 
 /**
+ * Check if a user exist
+ * @param username{string}
+ * @returns {Promise<boolean>}
+ */
+export const userExists = async username => {
+  const endpoint = `${giteaApiUrl}/users/${username}`
+
+  const res = await fetch(endpoint, {
+    method: 'GET',
+    mode,
+    headers,
+  })
+
+  return res.ok
+}
+
+/**
  * Get all repos
  * @returns {Promise<[Object]>}
  */

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1058,6 +1058,13 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+basic-auth@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
+
 bcrypt-pbkdf@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
@@ -2188,6 +2195,11 @@ depd@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
 
 dequal@2.0.2:
   version "2.0.2"
@@ -4405,6 +4417,17 @@ moment@^2.27.0:
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
 
+morgan@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
+  integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
+  dependencies:
+    basic-auth "~2.0.1"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-finished "~2.3.0"
+    on-headers "~1.0.2"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -4809,6 +4832,11 @@ on-finished@~2.3.0:
   integrity sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=
   dependencies:
     ee-first "1.1.1"
+
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
 
 once@^1.3.0, once@^1.3.1, once@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
SSG causes some problems because of the way `_app.js` set up.

* Add `UserExists` util function.
* SSR `mine` page.
* Migrate all pages: SSG -> SSR.
   - The way authentication works breaks SSG in production. SSR is the next best thing!
   - It worked before because Next re-run the build on each request in development, see [docs](https://nextjs.org/docs/basic-features/data-fetching#runs-on-every-request-in-development)
* Configure frontend logger for production.
   - Previously there was no output from when running in production.
* Remove `ref` from the `useDefaultBranchFiles`.
  - Gitea returns the files in the default branch if there's no ref provided.