### PR TITLE
.dev auto-deploys

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,7 +95,7 @@ jobs:
           cache-to: type=local,dest=/tmp/.buildx-cache
 
   deploy:
-    if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master' }}
+    if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/abdo-dev'|| github.ref == 'refs/heads/kaspar-dev' }}
     name: Deploy to staging
     runs-on: ubuntu-20.04
     environment: staging
@@ -138,12 +138,12 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PAT }}
         continue-on-error: true
 
-      - name: Deploy to ${{ steps.branch.outputs.short_ref }}.staging.kitspace.org
+      - name: Deploy to ${{ steps.branch.outputs.short_ref }}.staging.kitspace.dev
         uses: kitspace/docker-remote-deployment-action@master
         env:
           POSTGRES_PASSWORD: ${{ secrets.STAGING_POSTGRES_ROOT_PASSWORD }}
           GITEA_SECRET_KEY: ${{ secrets.STAGING_GITEA_SECRET }}
-          KITSPACE_DOMAIN: ${{ steps.branch.outputs.short_ref }}.staging.kitspace.org
+          KITSPACE_DOMAIN: ${{ steps.branch.outputs.short_ref }}.staging.kitspace.dev
           KITSPACE_SCHEME: https
           KITSPACE_DEV_PORT: '80'
           CERTBOT_ENABLED: 'true'

--- a/README.md
+++ b/README.md
@@ -71,11 +71,14 @@ This is a NodeJS and [Express](https://expressjs.com/) server that processes all
 
 ## Auto Deploys
 
-This repo auto deploys the `dev` and `master` branches (whether e2e tests pass or not) to our staging servers. The intention is to merge/force push whatever you want to the `dev` branch to preview deployment. `master` on the other hand is never force pushed to and is ideally kept in a working state.
+This repo auto deploys the `master` branch (whether e2e tests pass or not) to our staging server.
 
-- https://dev.staging.kitspace.org
-- https://master.staging.kitspace.org
+- [master.staging.kitspace.dev](https://master.staging.kitspace.dev)
 
+We also auto deploy some development branches:
+
+- [abdo-dev.staging.kitspace.dev](https://abdo-dev.staging.kitspace.dev) (from [abdo-dev](https://github.com/kitspace/kitspace-v2/tree/abdo-dev), [@AbdulrhmnGhanem](https://github.com/AbdulrhmnGhanem)'s branch)
+- [kaspar-dev.staging.kitspace.dev](https://abdo-dev.staging.kitspace.dev) (from [kaspar-dev](https://github.com/kitspace/kitspace-v2/tree/kaspar-dev), [@kasbah](https://github.com/kasbah)'s branch)
 
 ## Running Integration Tests
 


### PR DESCRIPTION
I'm switching the auto-deploys domain to .dev because we could run into cookie issues when we finally deploy to the apex domain on .org. Additionally I've created two separate auto-deploys for our own branches. So the master branch deploy is now:

https://master.staging.kitspace.dev (hopefully we will see something here when this is merged) 

@AbdulrhmnGhanem you can push whatever you want to the `abdo-dev` branch and this should be deployed to:

https://abdo-dev.staging.kitspace.dev

I've added your public ssh key to authorized_keys so you should be able to login with `ubuntu@abdo-dev.staging.kitspace.dev`  when there are any issues (which there probably will be occasionally). 

My own branch is `kaspar-dev` which is deployed to: https://kaspar-dev.staging.kitspace.dev. We should make the e2e end tests run on an auto-deploy domain too. 