### PR TITLE
Add Cypress test runs groups

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -184,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: [chrome, edge, electron, firefox]
+        browser: [chrome, edge, electron]
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -257,6 +257,7 @@ jobs:
           working-directory: frontend
           record: true
           browser: ${{ matrix.browser }}
+          group: ${{ matrix.browser }}
 
   publish:
     name: Tag "latest"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -184,7 +184,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browsers: [chrome, edge, electron, firefox]
+        browser: [chrome, edge, electron, firefox]
 
     steps:
       - name: Check out the repo
@@ -206,7 +206,7 @@ jobs:
             | sed -n "/gitea/{N; p}" | sed '2q;d'| xargs git rev-parse --short )"
 
       - name: Install Microsoft Edge
-        if: ${{ matrix.browsers == 'edge' }}
+        if: ${{ matrix.browser == 'edge' }}
         timeout-minutes: 10
         shell: bash
         run: |
@@ -256,7 +256,7 @@ jobs:
           wait-on-timeout: 120
           working-directory: frontend
           record: true
-          browser: ${{ matrix.browsers }}
+          browser: ${{ matrix.browser }}
 
   publish:
     name: Tag "latest"


### PR DESCRIPTION
https://docs.cypress.io/guides/guides/parallelization#Grouping-test-runs
- Previously, all tests used the default group which made the results of each browser overwrites other browsers.
- Groups are needed for parallelization if a testing matrix (in our case multiple browsers) is used.