### PR TITLE
Avoid flashing loaders for public paths

### DIFF
--- a/frontend/src/components/Page.js
+++ b/frontend/src/components/Page.js
@@ -10,7 +10,7 @@ import NavBar from './NavBar'
 import styles from './Page.module.scss'
 
 const Content = ({ requireSignIn, requireSignOut, contentFullSize, children }) => {
-  const { push, pathname } = useRouter()
+  const { pathname, replace } = useRouter()
   const [loading, setLoading] = useState(true)
   const { isAuthenticated } = useContext(AuthContext)
 
@@ -18,13 +18,13 @@ const Content = ({ requireSignIn, requireSignOut, contentFullSize, children }) =
     const isAuthenticated = window?.session.user != null
 
     if (requireSignIn && !isAuthenticated) {
-      push(`/login?redirect=${pathname}`)
+      replace(`/login?redirect=${pathname}`)
     } else if (requireSignOut && isAuthenticated) {
-      push('/')
+      replace('/')
     } else {
       setLoading(false)
     }
-  }, [loading, requireSignIn, requireSignOut, pathname, isAuthenticated, push])
+  }, [loading, requireSignIn, requireSignOut, pathname, isAuthenticated, replace])
 
   const isPublicPath = !(requireSignIn || requireSignOut)
   if (isPublicPath) {

--- a/frontend/src/components/Page.js
+++ b/frontend/src/components/Page.js
@@ -12,7 +12,14 @@ import styles from './Page.module.scss'
 const Content = ({ requireSignIn, requireSignOut, contentFullSize, children }) => {
   const { pathname, replace } = useRouter()
   const [loading, setLoading] = useState(true)
+  const [throttledLoader, setThrottledLoader] = useState(false)
   const { isAuthenticated } = useContext(AuthContext)
+
+  useEffect(() => {
+    setTimeout(() => {
+      setThrottledLoader(true)
+    }, 200)
+  }, [])
 
   useEffect(() => {
     const isAuthenticated = window?.session.user != null
@@ -32,7 +39,7 @@ const Content = ({ requireSignIn, requireSignOut, contentFullSize, children }) =
     return <Container contentFullSize={contentFullSize}>{children}</Container>
   }
 
-  if (loading) {
+  if (loading && throttledLoader) {
     return (
       <Loader style={{ margin: 'auto' }} active>
         Loading...
@@ -40,7 +47,9 @@ const Content = ({ requireSignIn, requireSignOut, contentFullSize, children }) =
     )
   }
 
-  return <Container contentFullSize={contentFullSize}>{children}</Container>
+  return throttledLoader ? (
+    <Container contentFullSize={contentFullSize}>{children}</Container>
+  ) : null
 }
 
 const Container = ({ contentFullSize, children }) => (

--- a/frontend/src/components/Page.js
+++ b/frontend/src/components/Page.js
@@ -1,8 +1,10 @@
-import React, { useEffect, useState } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { string, bool, node } from 'prop-types'
-
-import { Loader } from 'semantic-ui-react'
 import { useRouter } from 'next/router'
+import { Loader } from 'semantic-ui-react'
+
+import { AuthContext } from '@contexts/AuthContext'
+
 import Head from './Head'
 import NavBar from './NavBar'
 import styles from './Page.module.scss'
@@ -10,18 +12,25 @@ import styles from './Page.module.scss'
 const Content = ({ requireSignIn, requireSignOut, contentFullSize, children }) => {
   const { push, pathname } = useRouter()
   const [loading, setLoading] = useState(true)
+  const { isAuthenticated } = useContext(AuthContext)
 
   useEffect(() => {
-    const isAuthenticated = window.session?.user !== null
+    const isAuthenticated = window?.session.user != null
 
     if (requireSignIn && !isAuthenticated) {
-      push(`/login?redirect=${pathname}`).then()
+      push(`/login?redirect=${pathname}`)
     } else if (requireSignOut && isAuthenticated) {
-      push('/').then()
+      push('/')
     } else {
       setLoading(false)
     }
-  }, [loading, requireSignIn, requireSignOut, pathname, push])
+  }, [loading, requireSignIn, requireSignOut, pathname, isAuthenticated, push])
+
+  const isPublicPath = !(requireSignIn || requireSignOut)
+  if (isPublicPath) {
+    // render the page immediately without checking the authentication status.
+    return <Container contentFullSize={contentFullSize}>{children}</Container>
+  }
 
   if (loading) {
     return (
@@ -30,15 +39,18 @@ const Content = ({ requireSignIn, requireSignOut, contentFullSize, children }) =
       </Loader>
     )
   }
-  return (
-    <div
-      className={contentFullSize ? styles.minimalContainer : styles.container}
-      data-cy="page-container"
-    >
-      {children}
-    </div>
-  )
+
+  return <Container contentFullSize={contentFullSize}>{children}</Container>
 }
+
+const Container = ({ contentFullSize, children }) => (
+  <main
+    data-cy="page-container"
+    className={contentFullSize ? styles.minimalContainer : styles.container}
+  >
+    {children}
+  </main>
+)
 
 const Page = ({
   title,


### PR DESCRIPTION
Fixes #152.

- The problem isn't with data fetching because Next only redirects when the data is ready when using `getServerSideProps`. Actually, this loader has no idea about the loading status of the content.
- The authentication status is read from `window.session` not a remote source, suspense won't make a difference here.
- Loaders were displayed to prevent flashing content for protected paths.
- Paths neither marked as `requireSignIn` nor `requireSingOut` are considered public paths; users can see its content whether they are logged in or not.
-Throttle loaders for authenticated routes. Leave a period in which the loader doesn't show up, during this period the `loading` state changes which results in flashing the loader.