### PR TITLE
Fix missing `original_url` for synced repos

### DIFF
--- a/frontend/cypress/integration/search.spec.js
+++ b/frontend/cypress/integration/search.spec.js
@@ -66,7 +66,6 @@ describe('Search', () => {
 
   it('should use `q` from query parameters', () => {
     const username = getFakeUsername()
-
     const email = faker.unique(faker.internet.email)
     const password = '123456'
 

--- a/frontend/cypress/integration/syncRepo.spec.js
+++ b/frontend/cypress/integration/syncRepo.spec.js
@@ -24,6 +24,7 @@ describe('Syncing a project behavior validation', () => {
     cy.signIn(username, password)
     cy.get('[data-cy=logout-button]')
 
+    cy.forceVisit('/projects/new')
     cy.get('input:first').type(syncedRepoUrl)
     cy.get('button').contains('Sync').click()
     cy.get('[data-cy=sync-result-message]').should('have.class', 'green')

--- a/frontend/cypress/integration/syncRepo.spec.js
+++ b/frontend/cypress/integration/syncRepo.spec.js
@@ -3,9 +3,6 @@ import faker from 'faker'
 import { getFakeUsername } from '../support/getFakeUsername'
 
 describe('Syncing a project behavior validation', () => {
-  const syncedRepoUrl = 'https://github.com/AbdulrhmnGhanem/light-test-repo'
-  const repoName = 'light-test-repo'
-
   before(() => {
     /*
      * The purpose of this isn't actually visiting the homepage.
@@ -15,6 +12,9 @@ describe('Syncing a project behavior validation', () => {
   })
 
   it('should sync a repo on gitea', () => {
+    const syncedRepoUrl = 'https://github.com/AbdulrhmnGhanem/light-test-repo'
+    const repoName = 'light-test-repo'
+
     const username = getFakeUsername()
     const email = faker.unique(faker.internet.email)
     const password = '123456'
@@ -36,5 +36,36 @@ describe('Syncing a project behavior validation', () => {
     // assert the repo is on `{frontend}/projects/mine`
     cy.visit(`/${username}`)
     cy.get('[data-cy=project-card]').contains(repoName)
+  })
+
+  it('should display original url for synced repos', () => {
+    const username = getFakeUsername()
+    const email = faker.unique(faker.internet.email)
+    const password = '123456'
+
+    const repoName = 'CH330_Hardware'
+    const syncedRepoUrl = 'https://github.com/kitspace-forks/CH330_Hardware'
+
+    cy.createUser(username, email, password)
+    cy.visit('/login')
+    cy.signIn(username, password)
+    cy.get('[data-cy=logout-button]')
+
+    cy.forceVisit('/projects/new')
+
+    // Migrate the repo
+    cy.get('input:first').type(syncedRepoUrl)
+    cy.get('button').contains('Sync').click()
+
+    // Wait for redirection for project page
+    cy.url({ timeout: 60_000 }).should('contain', `${username}/${repoName}`)
+
+    // The info bar should include the original url
+    cy.get('[data-cy=original-url] > a', { timeout: 60_000 })
+      .should('have.attr', 'href')
+      .and('include', 'github.com/kitspace-forks')
+      .then(href =>
+        assert(href === syncedRepoUrl, 'The href value is the synced repo url'),
+      )
   })
 })

--- a/frontend/cypress/integration/syncRepo.spec.js
+++ b/frontend/cypress/integration/syncRepo.spec.js
@@ -24,8 +24,6 @@ describe('Syncing a project behavior validation', () => {
     cy.signIn(username, password)
     cy.get('[data-cy=logout-button]')
 
-    cy.forceVisit('/projects/new')
-
     cy.get('input:first').type(syncedRepoUrl)
     cy.get('button').contains('Sync').click()
     cy.get('[data-cy=sync-result-message]').should('have.class', 'green')

--- a/frontend/cypress/integration/uploadProject.spec.js
+++ b/frontend/cypress/integration/uploadProject.spec.js
@@ -13,7 +13,6 @@ describe('Upload project', () => {
 
   it('should create a project and redirect to its update route on file drop', () => {
     const username = getFakeUsername()
-
     const email = faker.unique(faker.internet.email)
     const password = '123456'
 

--- a/frontend/cypress/support/getFakeUsername.js
+++ b/frontend/cypress/support/getFakeUsername.js
@@ -7,6 +7,7 @@ import faker from 'faker'
 export const getFakeUsername = () => {
   let username
   try {
+    // It might fail to find unique username in the specified `maxTime`
     username = faker.unique(faker.name.firstName, undefined, { maxTime: 50 })
   } catch (e) {
     username = faker.name.firstName()

--- a/frontend/src/components/Board/InfoBar.js
+++ b/frontend/src/components/Board/InfoBar.js
@@ -3,14 +3,16 @@ import { string } from 'prop-types'
 
 import styles from './InfoBar.module.scss'
 
-const InfoBar = ({ name, url, site, description }) => {
+const InfoBar = ({ name, originalUrl, site, description }) => {
   // https://github.com/Jan--Henrik/CH330_Hardware -> github.com/Jan--Henrik
-  const ownerText = url?.split('/').slice(2, 4).join('/')
+  const ownerText = originalUrl?.split('/').slice(2, 4).join('/')
 
   const siteCom = site ? (
     <span>
       {'  |  '}
-      <a href={site}>homepage</a>
+      <a href={site} target="_blank" rel="noopener noreferrer">
+        homepage
+      </a>
     </span>
   ) : null
 
@@ -21,8 +23,10 @@ const InfoBar = ({ name, url, site, description }) => {
           <div data-cy="project-title" className={styles.titleText}>
             {name}
           </div>
-          <div className={styles.subtitleText}>
-            <a href={url}>{ownerText}</a>
+          <div data-cy="original-url" className={styles.subtitleText}>
+            <a href={originalUrl} target="_blank" rel="noopener noreferrer">
+              {ownerText}
+            </a>
             {siteCom}
           </div>
         </div>
@@ -38,7 +42,7 @@ const InfoBar = ({ name, url, site, description }) => {
 
 InfoBar.propTypes = {
   name: string.isRequired,
-  url: string.isRequired,
+  originalUrl: string.isRequired,
   site: string.isRequired,
   description: string.isRequired,
 }

--- a/frontend/src/components/SharedProjectPage/elements.js
+++ b/frontend/src/components/SharedProjectPage/elements.js
@@ -34,7 +34,7 @@ const PageElements = ({
   description,
   projectName,
   projectFullname,
-  url,
+  originalUrl,
   boardAssetsExist,
   readmeExists,
   kitspaceYAMLExists,
@@ -156,7 +156,7 @@ const PageElements = ({
     <>
       <InfoBar
         name={projectName}
-        url={url}
+        originalUrl={originalUrl}
         site={kitspaceYAML?.site}
         description={description}
       />
@@ -291,7 +291,7 @@ PageElements.propTypes = {
   description: string.isRequired,
   projectName: string.isRequired,
   projectFullname: string.isRequired,
-  url: string.isRequired,
+  originalUrl: string.isRequired,
   boardAssetsExist: bool.isRequired,
   readmeExists: bool.isRequired,
   kitspaceYAMLExists: bool.isRequired,

--- a/frontend/src/pages/[username]/[projectName]/[multiProjectName]/index.js
+++ b/frontend/src/pages/[username]/[projectName]/[multiProjectName]/index.js
@@ -80,7 +80,7 @@ export const getServerSideProps = async ({ params, query, req }) => {
         kitspaceYAMLExists,
         finishedProcessing,
         description: projectKitspaceYAML?.summary || repo?.description,
-        url: repo?.original_url,
+        originalUrl: repo?.original_url,
       },
     }
   }

--- a/frontend/src/pages/[username]/[projectName]/index.js
+++ b/frontend/src/pages/[username]/[projectName]/index.js
@@ -91,7 +91,7 @@ export const getServerSideProps = async ({ params, query, req }) => {
         kitspaceYAMLExists,
         finishedProcessing,
         description: kitspaceYAML?.summary || repo?.description,
-        url: repo?.original_url,
+        originalUrl: repo?.original_url,
       },
     }
   }

--- a/frontend/src/pages/search.js
+++ b/frontend/src/pages/search.js
@@ -114,6 +114,17 @@ const SearchForm = () => {
     push(`/search?q=${form.query}`, undefined, { shallow: true })
   }
 
+  useEffect(() => {
+    /* eslint-disable react-hooks/exhaustive-deps */
+    /*
+      ! The ignored dependency is `push` which isn't actually a dependency for this usecase; it won't change.
+      ! Adding `push` to the deps array will cause infinite fetching;
+      ! on first page mount the value of `push` changes which triggers the hook.
+      ! The hook will call `push` and and a new page(the json from next SSR) will load resulting in infinite fetching.
+    */
+    if (form.query === '') onClear()
+  }, [form.query])
+
   return (
     <div className={styles.searchForm}>
       <Form onSubmit={onSubmit}>

--- a/frontend/src/pages/search.js
+++ b/frontend/src/pages/search.js
@@ -114,17 +114,6 @@ const SearchForm = () => {
     push(`/search?q=${form.query}`, undefined, { shallow: true })
   }
 
-  useEffect(() => {
-    /* eslint-disable react-hooks/exhaustive-deps */
-    /*
-      ! The ignored dependency is `push` which isn't actually a dependency for this usecase; it won't change.
-      ! Adding `push` to the deps array will cause infinite fetching;
-      ! on first page mount the value of `push` changes which triggers the hook.
-      ! The hook will call `push` and and a new page(the json from next SSR) will load resulting in infinite fetching.
-    */
-    if (form.query === '') onClear()
-  }, [form.query])
-
   return (
     <div className={styles.searchForm}>
       <Form onSubmit={onSubmit}>


### PR DESCRIPTION
Based on #179.

- 46feeff: Update gitea submodule @730051a63, see https://github.com/kitspace/gitea/pull/18.
- https://github.com/kitspace/kitspace-v2/commit/0af83ab92cce97274155f207e687317fa8c8d1d8: Add e2e test `should display original url for synced repos`.
##
The problem was in the migration logic, not the presentation layer. To see the result, sync a new repo.