### PR TITLE
Fix conflicting project names modal

### DIFF
--- a/frontend/cypress/integration/uploadProject.spec.js
+++ b/frontend/cypress/integration/uploadProject.spec.js
@@ -89,8 +89,8 @@ describe('User projects name collision', () => {
     // Collision modal should open
     cy.get('[data-cy=collision-modal]').should('be.visible')
 
-    // `Choose different name` should be disabled as the user haven't changed the name yet
-    cy.get('[data-cy=collision-different-name]').should('be.disabled')
+    // The update button should get rendered and the different name button shouldn't exist.
+    cy.get('[data-cy=collision-different-name]').should('not.exist')
     cy.get('[data-cy=collision-update]').should('be.enabled')
   })
 

--- a/frontend/src/pages/projects/new.js
+++ b/frontend/src/pages/projects/new.js
@@ -162,6 +162,8 @@ const Upload = ({ user, csrf }) => {
     }
   }, [form.name, validateProjectName])
 
+  const didChangeName = originalProjectName !== form.name
+
   return (
     <>
       <DropZone onDrop={onDrop} style={{ maxWidth: '70%', margin: 'auto' }} />
@@ -181,7 +183,7 @@ const Upload = ({ user, csrf }) => {
             <Form.Field
               fluid
               control={Input}
-              label="Project name"
+              label={didChangeName ? 'New project name' : 'Project name'}
               name="name"
               value={form.name || ''}
               onChange={onChange}
@@ -190,21 +192,22 @@ const Upload = ({ user, csrf }) => {
           </Form>
         </Modal.Content>
         <Modal.Actions>
-          <Button
-            data-cy="collision-different-name"
-            content="Choose different name"
-            color="green"
-            disabled={!isValidProjectName}
-            onClick={onDifferentName}
-          />
-          <Button
-            data-cy="collision-update"
-            content="Update existing project"
-            color="yellow"
-            onClick={onUpdateExisting}
-            // When the modal pops if they change the project name, disable the `Update existing project` button
-            disabled={originalProjectName !== form.name}
-          />
+          {didChangeName ? (
+            <Button
+              data-cy="collision-different-name"
+              content="OK"
+              color="green"
+              disabled={!isValidProjectName}
+              onClick={onDifferentName}
+            />
+          ) : (
+            <Button
+              data-cy="collision-update"
+              content={`Add files to "${originalProjectName}"`}
+              color="green"
+              onClick={onUpdateExisting}
+            />
+          )}
         </Modal.Actions>
       </Modal>
     </>

--- a/frontend/src/pages/projects/new.js
+++ b/frontend/src/pages/projects/new.js
@@ -204,7 +204,7 @@ const Upload = ({ user, csrf }) => {
             <Button
               data-cy="collision-update"
               content={`Add files to "${originalProjectName}"`}
-              color="green"
+              color="orange"
               onClick={onUpdateExisting}
             />
           )}


### PR DESCRIPTION
Fixes #90.
##
- The rename button is "OK" after changing the name.
- The upload to the same project is `Add file to ${projectName}`.
##
### Add files to the same project
![image](https://user-images.githubusercontent.com/37152329/128459708-38b2361c-369b-4e39-af20-01c536f72b8f.png)
##
### Changing the project name
![image](https://user-images.githubusercontent.com/37152329/128459742-30280a2e-a362-4702-b37b-e86bf3d6648f.png)
##
### Changing the project name though the new name is also already used
![image](https://user-images.githubusercontent.com/37152329/128459767-eb5d995a-c019-4e5a-8174-4d33057727d5.png)
