### PR TITLE
Disable schematic processing

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -64,7 +64,6 @@ or
         - `images/top-meta.png`
         - `images/top-with-background.png`
         - `images/layout.svg`
-        - `images/schematic.svg`
         - `1-click-BOM.tsv`
         - `bom-info.json`
         - `interactive_bom.json`
@@ -77,7 +76,7 @@ or
 
 #### POST `/process-file`
 
-- Multi-part form data with an input name of "upload" and a filename that ends with `.kicad_pcb` or `.sch`
+- Multi-part form data with an input name of "upload" and a filename that ends with `.kicad_pcb`
 - Must include a header `Authorization` with contents `Bearer ${KITSPACE_PROCESSOR_REMOTE_API_TOKEN}`
 
 Responds with:
@@ -102,7 +101,6 @@ Responds like "GET `/files/[user]/[project]/[git-ref]/[file]`" above.
 The remote API only supports:
 
 - `images/layout.svg`
-- `images/schematic.svg`
 
 ## Development
 

--- a/processor/src/watcher.js
+++ b/processor/src/watcher.js
@@ -10,7 +10,6 @@ const processGerbers = require('./tasks/processGerbers')
 const processBOM = require('./tasks/processBOM')
 const processIBOM = require('./tasks/processIBOM')
 const processKicadPCB = require('./tasks/processKicadPCB')
-const processSchematics = require('./tasks/processSchematics')
 
 const running = {}
 function watch(events, repoDir = '/repositories') {
@@ -114,7 +113,6 @@ async function processRepo(events, repoDir, gitDir) {
       .then(() => events.emit('done', kitspaceYamlJson))
       .catch(err => events.emit('failed', kitspaceYamlJson, err)),
     processPCB(),
-    processSchematics(events, checkoutDir, kitspaceYaml, filesDir),
     processBOM(events, checkoutDir, kitspaceYaml, filesDir),
     processIBOM(events, checkoutDir, kitspaceYaml, filesDir, hash, name),
   ])

--- a/processor/test/integration/test_projects.js
+++ b/processor/test/integration/test_projects.js
@@ -20,7 +20,6 @@ const standardProjectFiles = [
   'images/top-meta.png',
   'images/top-with-background.png',
   'images/layout.svg',
-  'images/schematic.svg',
   '1-click-BOM.tsv',
   'interactive_bom.json',
   'gerber-info.json',

--- a/processor/test/integration/test_remote.js
+++ b/processor/test/integration/test_remote.js
@@ -67,40 +67,6 @@ describe('remote API', () => {
     r = await this.supertest.get(layoutSvg).expect(200)
   })
 
-  it('plots schematic.svg', async () => {
-    let r = await this.supertest
-      .post('/process-file')
-      .set('Authorization', `Bearer ${REMOTE_API_TOKEN}`)
-      .attach('upload', path.join(__dirname, 'fixtures/ulx3s.sch'))
-      .expect(202)
-    assert(r.body.id != null)
-    const schematicSvgStatus = `/processed/status/${r.body.id}/images/schematic.svg`
-    const schematicSvg = `/processed/files/${r.body.id}/images/schematic.svg`
-    r = await this.supertest.get(schematicSvgStatus)
-    while (r.body.status === 'in_progress') {
-      r = await this.supertest.get(schematicSvgStatus)
-    }
-    assert(r.body.status === 'done')
-    r = await this.supertest.get(schematicSvg).expect(200)
-  })
-
-  it('plots push-on-hold-off schematic.svg', async () => {
-    let r = await this.supertest
-      .post('/process-file')
-      .set('Authorization', `Bearer ${REMOTE_API_TOKEN}`)
-      .attach('upload', path.join(__dirname, 'fixtures/push-on-hold-off.sch'))
-      .expect(202)
-    assert(r.body.id != null)
-    const schematicSvgStatus = `/processed/status/${r.body.id}/images/schematic.svg`
-    const schematicSvg = `/processed/files/${r.body.id}/images/schematic.svg`
-    r = await this.supertest.get(schematicSvgStatus)
-    while (r.body.status === 'in_progress') {
-      r = await this.supertest.get(schematicSvgStatus)
-    }
-    assert(r.body.status === 'done')
-    r = await this.supertest.get(schematicSvg).expect(200)
-  })
-
   afterEach(async () => {
     this.app.stop()
     await exec(`rm -rf ${tmpDir}`)


### PR DESCRIPTION
It's taking up too much processor time, pegging 2-cores at 100% on our staging server. 