### PR TITLE
Avoid rebuilding images when deploying already built images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -46,7 +46,16 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_PAT }}
         continue-on-error: true
 
+      - name: Pull frontend image
+        id: pull_frontend
+        shell: bash
+        run: docker pull ghcr.io/kitspace/frontend:${{ steps.sha.outputs.sha_short }}
+        continue-on-error: true
+
       - name: Build and push frontend
+        # If the previous step failed, i.e., there's no image tagged:
+        # frontend:${{gitea_sha_short}} in ghcr, build image and push it
+        if: steps.pull_frontend.outcome != 'success'
         uses: docker/build-push-action@v2
         with:
           context: ./frontend
@@ -56,7 +65,16 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
 
+      - name: Pull processor image
+        id: pull_processor
+        shell: bash
+        run: docker pull ghcr.io/kitspace/processor:${{ steps.sha.outputs.sha_short }}
+        continue-on-error: true
+
       - name: Build and push processor
+        # If the previous step failed, i.e., there's no image tagged:
+        # processor:${{gitea_sha_short}} in ghcr, build image and push it
+        if: steps.pull_processor.outcome != 'success'
         uses: docker/build-push-action@v2
         with:
           context: ./processor


### PR DESCRIPTION
When trying a branch (deploying it to staging), the docker images get unnecessarily rebuilt.

This reduced the [first time build](https://github.com/kitspace/kitspace-v2/runs/3603738809) from `5m 4s` to `1m 39s` for [redeployment build](https://github.com/kitspace/kitspace-v2/runs/3603794357?check_suite_focus=true).