### PR TITLE
Fix not prefetching `Link`s

### DIFF
--- a/frontend/src/components/Board/BuyParts/InstallPrompt.js
+++ b/frontend/src/components/Board/BuyParts/InstallPrompt.js
@@ -84,9 +84,12 @@ const PleaseInstall = ({ install1ClickBOMCallback }) => (
 const NotCompatible = () => (
   <Message attached warning>
     <Icon name="attention" />
-    Sorry, the <Link href="/1-click-bom">1-click BOM extension</Link> is not yet
-    available for your browser. Only the Digikey add-to-cart links work fully,
-    Farnell and Newark should work but the references will not be added as
+    Sorry, the{' '}
+    <Link href="/1-click-bom">
+      <a>1-click BOM extension</a>
+    </Link>{' '}
+    is not yet available for your browser. Only the Digikey add-to-cart links work
+    fully, Farnell and Newark should work but the references will not be added as
     line-notes.
   </Message>
 )

--- a/frontend/src/components/ProjectCard.js
+++ b/frontend/src/components/ProjectCard.js
@@ -19,8 +19,8 @@ const ProjectCard = ({
     isMultiProject ? name : null,
   )
   return (
-    <Link href={`/${fullname}/${isMultiProject ? name : ''}`} passHref>
-      <Card data-cy="project-card" className={styles.card}>
+    <Link href={`${fullname}/${isMultiProject ? name : ''}`} passHref>
+      <Card as="a" data-cy="project-card" className={styles.card}>
         <div className={styles.thumbnail}>
           <div>
             {isLoading || isError ? null : (

--- a/frontend/src/pages/1-click-bom.js
+++ b/frontend/src/pages/1-click-bom.js
@@ -31,7 +31,10 @@ const OneClickBom = () => (
       sites like Digikey and Mouser. It lets you simply click on the &quot;buy
       parts&quot; links on Kitspace to get the right parts. You can also use it
       directly with your own spreadsheets or with our{' '}
-      <Link href="/bom-builder">BOM Builder</Link> tool.
+      <Link href="/bom-builder">
+        <a>BOM Builder</a>
+      </Link>{' '}
+      tool.
     </p>
     <p>
       <a href="https://github.com/kitspace/1clickBOM#readme">

--- a/frontend/src/pages/bom-builder.js
+++ b/frontend/src/pages/bom-builder.js
@@ -10,7 +10,9 @@ const BomBuilder = () => (
       The BOM Builder allows you to automatically find in-stock components and
       alternatives across distributors and lets you add entire bill of materials
       directly to shopping carts by connecting up to{' '}
-      <Link href="/1-click-bom">1-click BOM</Link>
+      <Link href="/1-click-bom">
+        <a>1-click BOM</a>
+      </Link>
     </p>
     <p>
       In our experience this can cut the purchasing time down from a few hours to a

--- a/frontend/src/pages/search.js
+++ b/frontend/src/pages/search.js
@@ -87,7 +87,10 @@ const CardsGrid = ({ initialProjects }) => {
   if (projects?.length === 0) {
     return (
       <p className={styles.noMatching}>
-        Sorry, no result. <Link href="/projects/new">Add your project!</Link>
+        Sorry, no result.{' '}
+        <Link href="/projects/new">
+          <a>Add your project!</a>
+        </Link>
       </p>
     )
   }


### PR DESCRIPTION
- Render `ProjectCard` as an `a` tag.
- Wrap plain text links in the `<a>` tag.
- Fixes #209 
- See https://github.com/vercel/next.js/discussions/29496