### PR TITLE
Fix mismatch between error pages and its status response

### DIFF
--- a/frontend/cypress/integration/errorPage.spec.js
+++ b/frontend/cypress/integration/errorPage.spec.js
@@ -1,9 +1,15 @@
 describe('Error pages messages', () => {
   it("should show 'This page could not be found.' for 404", () => {
-    cy.visit('/not-found')
+    cy.visit('/not-found', { failOnStatusCode: false })
     cy.get('[data-cy="status-message"]').should(
       'have.text',
       'This page could not be found.',
     )
+  })
+
+  it('should return 404 status code for not-found pages', () => {
+    cy.request({ url: '/not-found', failOnStatusCode: false }).then(res => {
+      expect(res.status).to.eq(404)
+    })
   })
 })

--- a/frontend/src/pages/404.js
+++ b/frontend/src/pages/404.js
@@ -1,0 +1,5 @@
+import ErrorPage from './_error'
+
+const Custom404 = () => <ErrorPage statusCode={404} />
+
+export default Custom404

--- a/frontend/src/pages/[username]/[projectName]/[multiProjectName]/index.js
+++ b/frontend/src/pages/[username]/[projectName]/[multiProjectName]/index.js
@@ -10,12 +10,12 @@ import {
   getReadme,
 } from '@utils/projectPage'
 import SharedProjectPage from '@components/SharedProjectPage'
-import ErrorPage from '@pages/_error'
+import Custom404 from '@pages/404'
 
 const MultiProjectPage = props =>
-  props.notFound ? <ErrorPage statusCode={404} /> : <SharedProjectPage {...props} />
+  props.notFound ? <Custom404 /> : <SharedProjectPage {...props} />
 
-MultiProjectPage.getInitialProps = async ({ asPath, query, req }) => {
+MultiProjectPage.getInitialProps = async ({ asPath, query, req, res }) => {
   const processorUrl = process.env.KITSPACE_PROCESSOR_URL
   // `repoFullname` is resolved by matching its name against the `page` dir.
   // Then it's used to access the repo by the Gitea API.
@@ -85,6 +85,7 @@ MultiProjectPage.getInitialProps = async ({ asPath, query, req }) => {
     }
   }
 
+  res.statusCode = 404
   return { notFound: true }
 }
 

--- a/frontend/src/pages/[username]/[projectName]/index.js
+++ b/frontend/src/pages/[username]/[projectName]/index.js
@@ -45,7 +45,7 @@ const SubProjectsGrid = ({ projects, parentProject }) => {
   )
 }
 
-ProjectPage.getInitialProps = async ({ asPath, query, req }) => {
+ProjectPage.getInitialProps = async ({ asPath, query, req, res }) => {
   const [ignored, username, projectName] = asPath.split('/')
 
   const processorUrl = process.env.KITSPACE_PROCESSOR_URL
@@ -115,6 +115,8 @@ ProjectPage.getInitialProps = async ({ asPath, query, req }) => {
       originalUrl: repo?.original_url,
     }
   }
+
+  res.statusCode = 404
   return { notFound: true }
 }
 

--- a/frontend/src/pages/_error.js
+++ b/frontend/src/pages/_error.js
@@ -5,13 +5,6 @@ import Head from '@components/Head'
 import NavBar from '@components/NavBar'
 import Error from '@components/Error'
 
-export const getServerSideProps = ({ res, err, query }) => {
-  const statusCode =
-    query?.staticStatusCode ?? res?.staticStatusCode ?? err?.statusCode ?? 404
-
-  return { props: { statusCode } }
-}
-
 const ErrorPage = ({ statusCode }) => (
   <div style={{ maxHeight: '100vh', overflow: 'hidden' }}>
     <Head />
@@ -19,6 +12,13 @@ const ErrorPage = ({ statusCode }) => (
     <Error statusCode={statusCode} />
   </div>
 )
+
+ErrorPage.getInitialProps = ({ res, err, query }) => {
+  const statusCode =
+    query?.staticStatusCode ?? res?.staticStatusCode ?? err?.statusCode ?? 404
+
+  return { statusCode }
+}
 
 ErrorPage.propTypes = {
   statusCode: number.isRequired,

--- a/nginx/kitspace.template
+++ b/nginx/kitspace.template
@@ -9,13 +9,6 @@ server {
         return 200 "@KITSPACE_ROBOTS_TXT";
     }
 
-    error_page 404 500 501 502 503 504 506 507 508 510 511 /error/$status/index.html;
-
-    location /error/ {
-        internal;
-        root /srv/frontend/static_fallback/;
-    }
-
     location /static/ {
         root /srv/frontend/public/;
         autoindex on;


### PR DESCRIPTION
Fixes #211 
##
- See https://github.com/kitspace/gitea/pull/19/commits/eca2dd04feeff97c69a810c67c58793b45499abf
- For `getServerSideProps` returning `{ notFound: true}` is sufficient to return `404` as status code for the document.
- For `getInitialProps` had to set the status code manually on the `res` object. (Setting the status code in `ErrorPage.getIntialProps` doesn't work).
## status reponse for not found:
### user

![image](https://user-images.githubusercontent.com/37152329/137981105-5b038421-673f-4747-9753-8b7d13a1d7be.png)
### project

![image](https://user-images.githubusercontent.com/37152329/137981307-c3240ab2-8df9-41b5-ab18-6238319099e8.png)
### sub-project

![image](https://user-images.githubusercontent.com/37152329/137981529-f5f19865-b443-49c4-a42b-90f0aff7c9db.png)



