### PR TITLE
Make homepage fault-tolerant when requesting its data

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "body-parser": "^1.19.0",
     "browser-version": "^1.0.0",
     "csstype": "^2.6.2",
+    "exponential-backoff": "^3.1.0",
     "express": "^4.17.1",
     "file-loader": "^6.0.0",
     "file-selector": "^0.2.4",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2411,6 +2411,11 @@ exenv@^1.2.2:
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
   integrity sha1-KueOhdmJQVhnCwPUe+wfA72Ru50=
 
+exponential-backoff@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/exponential-backoff/-/exponential-backoff-3.1.0.tgz#9409c7e579131f8bd4b32d7d8094a911040f2e68"
+  integrity sha512-oBuz5SYz5zzyuHINoe9ooePwSu0xApKWgeNzok4hZ5YKXFh9zrQBEM15CXqoZkJJPuI2ArvqjPQd8UKJA753XA==
+
 express@^4.17.1:
   version "4.17.1"
   resolved "https://registry.yarnpkg.com/express/-/express-4.17.1.tgz#4491fc38605cf51f8629d39c2b5d026f98a4c134"


### PR DESCRIPTION
Sometimes the homepage returns 500 because one of the requests in the`getServerSideProps` failed. It uses exponential backoff to prevent it from flooding the server with requests if the failure is due to high traffic.