### PR TITLE
Fix multi projects redirect

### DIFF
--- a/frontend/cypress/integration/IBOM.spec.js
+++ b/frontend/cypress/integration/IBOM.spec.js
@@ -1,0 +1,101 @@
+import faker from 'faker'
+
+import { getFakeUsername } from '../support/getFakeUsername'
+
+describe('IBOM page', () => {
+  before(() => {
+    /*
+     * The purpose of this isn't actually visiting the homepage.
+     * Sometimes, the frontend has a slow startup time which results in a random failure.
+     */
+    cy.visit('/')
+  })
+
+  it('should redirect to the multi project page (multiproject)', () => {
+    const username = getFakeUsername()
+    const email = faker.unique(faker.internet.email)
+    const password = '123456'
+
+    cy.createUser(username, email, password)
+    cy.visit('/login')
+    cy.signIn(username, password)
+    cy.get('[data-cy=user-menu]')
+
+    cy.forceVisit('/projects/new')
+
+    const multiProjectsNames = ['alpha-spectrometer', 'electron-detector']
+    const multiProjectsRepoName = 'DIY_particle_detector'
+    const syncedRepoUrlMultiProjects =
+      'https://github.com/kitspace-forks/DIY_particle_detector'
+
+    /* Migrate the multiproject repo */
+    cy.get('[data-cy=sync-field]').type(syncedRepoUrlMultiProjects)
+    cy.get('button').contains('Sync').click()
+
+    // Wait for redirection for project page
+    cy.url({ timeout: 60_000 }).should(
+      'contain',
+      `${username}/${multiProjectsRepoName}`,
+    )
+    // Wait for the repo to finish migration, by checking the visibility of processing-loader.
+    cy.get('[data-cy=processing-loader]', { timeout: 60_000 })
+    // Wait for the repo to finish processing, by checking the visibility sub projects cards.
+    cy.get('[data-cy=project-card]', { timeout: 60_000 }).as('projectCards')
+
+    cy.get('@projectCards').should('have.length', multiProjectsNames.length)
+
+    // Go to IBOM page for a subproject
+    const subProjectName = multiProjectsNames[0]
+    cy.visit(`${username}/${multiProjectsRepoName}/${subProjectName}/IBOM`)
+
+    // Click on the title
+    cy.get('#title').click()
+
+    // It should redirect to the subproject page
+    cy.url({ timeout: 20_000 }).should(
+      'eq',
+      `${
+        Cypress.config().baseUrl
+      }/${username}/${multiProjectsRepoName}/${subProjectName}`,
+    )
+  })
+
+  it('should redirect to the multi project page', () => {
+    const username = getFakeUsername()
+    const email = faker.unique(faker.internet.email)
+    const password = '123456'
+
+    cy.createUser(username, email, password)
+    cy.visit('/login')
+    cy.signIn(username, password)
+    cy.get('[data-cy=user-menu]')
+
+    /* Migrate the normal repo */
+    cy.forceVisit('/projects/new')
+
+    const syncedRepoUrl = 'https://github.com/kitspace-forks/CH330_Hardware'
+    const normalRepoName = 'CH330_Hardware'
+
+    cy.get('[data-cy=sync-field]').type(syncedRepoUrl)
+    cy.get('button').contains('Sync').click()
+
+    // Wait for redirection for project page
+    cy.url({ timeout: 60_000 }).should('contain', `${username}/${normalRepoName}`)
+    // Wait for the repo to finish migration, by checking the visibility of processing-loader.
+    cy.get('[data-cy=processing-loader]', { timeout: 60_000 })
+    // Wait for the repo to finish processing, by checking the visibility of info-bar.
+    cy.get('[data-cy=info-bar]', { timeout: 60_000 }).should('be.visible')
+
+    // Go to IBOM page for a single (not multi) project
+    cy.visit(`${username}/${normalRepoName}/IBOM`)
+
+    // Click on the title
+    cy.get('#title').click()
+
+    // It should redirect to the subproject page
+    cy.url({ timeout: 20_000 }).should(
+      'eq',
+      `${Cypress.config().baseUrl}/${username}/${normalRepoName}`,
+    )
+  })
+})

--- a/frontend/cypress/integration/multiProject.spec.js
+++ b/frontend/cypress/integration/multiProject.spec.js
@@ -178,14 +178,17 @@ describe('Multi project page', () => {
     // Wait for the repo to finish migration, by checking the visibility of processing-loader.
     cy.get('[data-cy=processing-loader]', { timeout: 60_000 })
     // Wait for the repo to finish processing, by checking the visibility sub projects cards.
-    cy.get('[data-cy=project-card]', { timeout: 60_000 }).should(
-      'have.length',
-      multiProjectsNames.length,
-    )
+    cy.get('[data-cy=project-card]', { timeout: 60_000 }).as('projectCards')
 
-    // Go to the home page and click on a multiproject project card
-    const multiProjectName = multiProjectsNames[0]
-    cy.visit(`${username}/${multiProjectsRepoName}/${multiProjectName}`)
+    cy.get('@projectCards').should('have.length', multiProjectsNames.length)
+
+    // Click on a subproject project card
+    const subProjectName = multiProjectsNames[0]
+    cy.get('@projectCards').contains(subProjectName).click()
+    cy.url({ timeout: 20_000 }).should(
+      'include',
+      `${username}/${multiProjectsRepoName}/${subProjectName}`,
+    )
 
     // Different page elements should be visible.
     const pageComponents = [

--- a/frontend/cypress/integration/multiProject.spec.js
+++ b/frontend/cypress/integration/multiProject.spec.js
@@ -153,8 +153,6 @@ describe('Multi project page', () => {
     cy.visit('/')
   })
 
-  beforeEach(() => cy.clearCookies())
-
   it('should render the page components', () => {
     const username = getFakeUsername()
     const email = faker.unique(faker.internet.email)
@@ -186,7 +184,7 @@ describe('Multi project page', () => {
     const subProjectName = multiProjectsNames[0]
     cy.get('@projectCards').contains(subProjectName).click()
     cy.url({ timeout: 20_000 }).should(
-      'include',
+      'contain',
       `${username}/${multiProjectsRepoName}/${subProjectName}`,
     )
 

--- a/frontend/src/components/Board/IBOM.js
+++ b/frontend/src/components/Board/IBOM.js
@@ -6,19 +6,16 @@ import { Loader } from 'semantic-ui-react'
 
 import Page from '@components/Page'
 
-const IBOM = ({ repoFullname, html, pcbData }) => {
+const IBOM = ({ projectFullname, html, pcbData, projectHref }) => {
   const [ready, setReady] = useState(false)
-  const title = `${repoFullname} Kitspace Interactive Assembly Guide`
+  const title = `${projectFullname} Kitspace Interactive Assembly Guide`
 
   /*
     i.   set the `pcbdata` var needed by IBOM
     ii.  initialize IBOM
     iii. make the title anchor tag linking to the project page.
     iv.  prefetch project page.
-     */
-  /* eslint-disable no-template-curly-in-string */
-  const titleTemplate = '`<a href=/${pcbTitle}>${pcbTitle}</a>`'
-  const hrefTemplate = '`/${pcbTitle}`'
+  */
   const initScript = `
     var pcbdata = ${pcbData};
     document.getElementById('IBOM_script').addEventListener('load', () => {
@@ -26,11 +23,11 @@ const IBOM = ({ repoFullname, html, pcbData }) => {
       initBOM();
       const pcbTitle = pcbdata.metadata.title;
   
-      document.querySelector('#title').innerHTML = ${titleTemplate};
+      document.querySelector('#title').innerHTML = "<a href=/${projectHref}>${projectFullname}</a>";
       const head = document.head;
       const link = document.createElement("link");
       link.rel = "prefetch";
-      link.href = ${hrefTemplate};
+      link.href = "${projectHref}";
     });
     `
 
@@ -85,9 +82,10 @@ const IBOM = ({ repoFullname, html, pcbData }) => {
 }
 
 IBOM.propTypes = {
-  repoFullname: string.isRequired,
+  projectFullname: string.isRequired,
   html: string.isRequired,
   pcbData: string.isRequired,
+  projectHref: string.isRequired,
 }
 
 export default IBOM

--- a/frontend/src/pages/[username]/[projectName]/IBOM.js
+++ b/frontend/src/pages/[username]/[projectName]/IBOM.js
@@ -11,18 +11,23 @@ export const getServerSideProps = async ({ params }) => {
   )
 
   const processorUrl = process.env.KITSPACE_PROCESSOR_URL
-  const repoFullname = `${params.username}/${params.projectName}`
+  const projectFullname = `${params.username}/${params.projectName}`
   const interactiveBOMStatus = await fetch(
-    `${processorUrl}/status/${repoFullname}/HEAD/interactive_bom.json`,
+    `${processorUrl}/status/${projectFullname}/HEAD/interactive_bom.json`,
   ).then(r => r.json().then(body => body.status))
 
   if (interactiveBOMStatus === 'done') {
     const pcbData = await fetch(
-      `${processorUrl}/files/${repoFullname}/HEAD/interactive_bom.json`,
+      `${processorUrl}/files/${projectFullname}/HEAD/interactive_bom.json`,
     ).then(res => res.blob().then(b => b.text()))
 
     return {
-      props: { repoFullname, html: IBOMHtml, pcbData },
+      props: {
+        projectFullname,
+        html: IBOMHtml,
+        pcbData,
+        projectHref: projectFullname,
+      },
     }
   }
   return {

--- a/frontend/src/pages/[username]/[projectName]/[multiProjectName]/IBOM.js
+++ b/frontend/src/pages/[username]/[projectName]/[multiProjectName]/IBOM.js
@@ -10,18 +10,23 @@ export const getServerSideProps = async ({ params }) => {
   )
 
   const processorUrl = process.env.KITSPACE_PROCESSOR_URL
-  const repoFullname = `${params.username}/${params.projectName}`
+  const projectFullname = `${params.username}/${params.projectName}`
   const interactiveBOMStatus = await fetch(
-    `${processorUrl}/status/${repoFullname}/HEAD/${params.multiProjectName}/interactive_bom.json`,
+    `${processorUrl}/status/${projectFullname}/HEAD/${params.multiProjectName}/interactive_bom.json`,
   ).then(r => r.json().then(body => body.status))
 
   if (interactiveBOMStatus === 'done') {
     const pcbData = await fetch(
-      `${processorUrl}/files/${repoFullname}/HEAD/${params.multiProjectName}/interactive_bom.json`,
+      `${processorUrl}/files/${projectFullname}/HEAD/${params.multiProjectName}/interactive_bom.json`,
     ).then(res => res.blob().then(b => b.text()))
 
     return {
-      props: { repoFullname, html: IBOMHtml, pcbData },
+      props: {
+        projectFullname,
+        html: IBOMHtml,
+        pcbData,
+        projectHref: `${projectFullname}/${params.multiProjectName}`,
+      },
     }
   }
   return {


### PR DESCRIPTION
 - redirect to subproject on clicking the card on multi-project page
   - For multi-project, visiting `/[username]/[projectName]` displays a
    grid of subprojects. Clicking on any of the cards didn't redirect to
    the correct subproject page.
    - Update `multi-project.spec` to catch this bug.
- clicking on the IBOM title for multi-project doesn't redirect to the project page.
  - Added tests for this case for normal and multi-projects