### PR TITLE
Fix redirects not being passed to browser

### DIFF
--- a/frontend/cypress.json
+++ b/frontend/cypress.json
@@ -13,6 +13,6 @@
     "runMode": 3
   },
   "env": {
-    "home_url": "search"
+    "home_path": "/"
   }
 }

--- a/frontend/cypress/integration/authRedirects.spec.js
+++ b/frontend/cypress/integration/authRedirects.spec.js
@@ -72,7 +72,7 @@ describe('It validates redirects after login', () => {
     cy.signIn(username, password)
 
     // After a successful login the user is redirect to the homepage.
-    cy.url().should('eq', `${Cypress.config().baseUrl}/${Cypress.env('home_url')}`)
+    cy.url().should('eq', `${Cypress.config().baseUrl}${Cypress.env('home_path')}`)
   })
 
   it('should redirect to correct page if there is a redirect query', () => {
@@ -110,7 +110,7 @@ describe('It validates redirects after sing up', () => {
     cy.signUp(username, email, password)
 
     // After a successful sign up the user is redirect to the homepage.
-    cy.url().should('eq', `${Cypress.config().baseUrl}/${Cypress.env('home_url')}`)
+    cy.url().should('eq', `${Cypress.config().baseUrl}${Cypress.env('home_path')}`)
   })
 
   it('should redirect to correct page if there is a redirect query', () => {

--- a/frontend/src/components/Page.js
+++ b/frontend/src/components/Page.js
@@ -1,5 +1,4 @@
-import React, { useEffect } from 'react'
-import { useRouter } from 'next/router'
+import React from 'react'
 import { string, bool, node } from 'prop-types'
 
 import Head from './Head'
@@ -21,33 +20,6 @@ const Container = ({ contentFullSize, children }) => (
 )
 
 const Page = ({ title, initialQuery, contentFullSize, children }) => {
-  const { asPath, pathname, replace } = useRouter()
-
-  useEffect(() => {
-    /*
-     * On clicking on the login button from any page for e.g., '/1-click-bom',
-     * it redirects to '/login?redirect=/1-click-bom'
-     * After successful login the page must be reloaded, because cookies are injected on server-side
-     * This means a request: GET /login?redirect=1-click-bom will hit the server.
-     * The server will find the user is already logged in so it will redirect it to the `redirect` param in the url
-     * though by rewriting the response the server can't change the url displayed in the browser accordingly. This hook fixes it.
-     *
-     * Why can't we redirect first then reload the page to update the cookies?
-     * If the page to which we should redirect is protected behind authentication (uses `withRequireSignIn`) e.g., /settings
-     * The auth-handler will find that the user isn't authenticated and will redirect to login page once again.
-     */
-
-    const browserPath = asPath.split('?')[0]
-    const doesTheBrowserURLMismatchPathname = browserPath !== pathname
-    if (
-      doesTheBrowserURLMismatchPathname &&
-      pathname !== '/login' &&
-      browserPath !== '/'
-    ) {
-      replace(pathname, null, { shallow: true })
-    }
-  }, [asPath, pathname, replace])
-
   return (
     <SearchProvider initialQuery={initialQuery}>
       <Head title={title} />

--- a/frontend/src/pages/index.js
+++ b/frontend/src/pages/index.js
@@ -1,10 +1,5 @@
-export const getServerSideProps = async () => ({
-  redirect: {
-    destination: '/search',
-    permanent: true,
-  },
-})
+import Search from './search'
 
-const Home = () => {}
+const Home = Search
 
 export default Home

--- a/frontend/src/utils/authHandlers.js
+++ b/frontend/src/utils/authHandlers.js
@@ -4,7 +4,6 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 /**
  * @param {string} asPath the page path e.g., `/project/new`.
- * @returns
  */
 export const withRequireSignIn =
   asPath =>
@@ -14,9 +13,10 @@ export const withRequireSignIn =
   ({ req, res }) => {
     const session = req?.session ?? window?.session
 
-    if (!isAuthenticated(session)) {
+    const isRelativePath = asPath.startsWith('/')
+    if (!isAuthenticated(session) && isRelativePath) {
       if (res) {
-        res.writeHead(307, { Location: '/login' })
+        res.writeHead(307, { Location: `/login?redirect=${asPath}` })
         res.end()
       } else {
         Router.replace(`/login?redirect=${asPath}`)


### PR DESCRIPTION
The [main change is in gitea](https://github.com/kitspace/gitea/compare/d1342b36f1b5e4ac0271d0f01c5270cd087f3575...351aea301fad4e9084962870764d5a407e008a8c#diff-e5ab7b7f38f5bdc95204c297cb135ee314e614b2cc24e577aa20a27afcf4d604). Sorry about this one @AbdulrhmnGhanem. I realise the way this was behaving was really confusing.  It must have warped you understanding of http re-directs :D 

In the long run I will try and get rid of the `/__kitspace` hack. I think my own understanding of http and csrf prevention was lacking when I came up with it and we should be able to come up with something more sensible. 