### PR TITLE
Re-enable running e2e in parallel

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -222,6 +222,7 @@ jobs:
       fail-fast: false
       matrix:
         browser: [chrome, edge, electron]
+        containers: [1, 2, 3, 4]
 
     steps:
       - name: Setup Node 14
@@ -293,6 +294,7 @@ jobs:
           # This value is in seconds
           wait-on-timeout: 120
           working-directory: frontend
+          parallel: true
           record: true
           browser: ${{ matrix.browser }}
           group: ${{ matrix.browser }}


### PR DESCRIPTION
Cut the runtime for e2e by a factor of 4. The serial version runs in ~14.5 mins, the parallel version runs in ~5 mins.