### PR TITLE
404 instead of 500 for `ibom` page if the project doesn't exist

### DIFF
--- a/frontend/cypress/integration/IBOM.spec.js
+++ b/frontend/cypress/integration/IBOM.spec.js
@@ -11,7 +11,7 @@ describe('IBOM page', () => {
     cy.visit('/')
   })
 
-  it('should redirect to the multi project page (multiproject)', () => {
+  it('should redirect to project page (multi project)', () => {
     const username = getFakeUsername()
     const email = faker.unique(faker.internet.email)
     const password = '123456'
@@ -60,7 +60,7 @@ describe('IBOM page', () => {
     )
   })
 
-  it('should redirect to the multi project page', () => {
+  it('should redirect to the multi project page (normal project)', () => {
     const username = getFakeUsername()
     const email = faker.unique(faker.internet.email)
     const password = '123456'
@@ -96,6 +96,25 @@ describe('IBOM page', () => {
     cy.url({ timeout: 20_000 }).should(
       'eq',
       `${Cypress.config().baseUrl}/${username}/${normalRepoName}`,
+    )
+  })
+})
+
+describe('404 IBOM for nonexistent projects', () => {
+  it("should return 404 status code for IBOM if the project isn't found (multiproject)", () => {
+    cy.request({
+      url: '/someone/multi/project/IBOM',
+      failOnStatusCode: false,
+    }).then(res => {
+      expect(res.status).to.eq(404)
+    })
+  })
+
+  it("should return 404 status code for IBOM if the project isn't found (normal project)", () => {
+    cy.request({ url: '/someone/project/IBOM', failOnStatusCode: false }).then(
+      res => {
+        expect(res.status).to.eq(404)
+      },
     )
   })
 })

--- a/frontend/src/pages/[username]/[projectName]/IBOM.js
+++ b/frontend/src/pages/[username]/[projectName]/IBOM.js
@@ -14,7 +14,9 @@ export const getServerSideProps = async ({ params }) => {
   const projectFullname = `${params.username}/${params.projectName}`
   const interactiveBOMStatus = await fetch(
     `${processorUrl}/status/${projectFullname}/HEAD/interactive_bom.json`,
-  ).then(r => r.json().then(body => body.status))
+  )
+    .then(r => r.json().then(body => body.status))
+    .catch(() => 'fail')
 
   if (interactiveBOMStatus === 'done') {
     const pcbData = await fetch(

--- a/frontend/src/pages/[username]/[projectName]/[multiProjectName]/IBOM.js
+++ b/frontend/src/pages/[username]/[projectName]/[multiProjectName]/IBOM.js
@@ -13,7 +13,9 @@ export const getServerSideProps = async ({ params }) => {
   const projectFullname = `${params.username}/${params.projectName}`
   const interactiveBOMStatus = await fetch(
     `${processorUrl}/status/${projectFullname}/HEAD/${params.multiProjectName}/interactive_bom.json`,
-  ).then(r => r.json().then(body => body.status))
+  )
+    .then(r => r.json().then(body => body.status))
+    .catch(() => 'fail')
 
   if (interactiveBOMStatus === 'done') {
     const pcbData = await fetch(

--- a/frontend/src/pages/[username]/[projectName]/[multiProjectName]/index.js
+++ b/frontend/src/pages/[username]/[projectName]/[multiProjectName]/index.js
@@ -59,6 +59,7 @@ MultiProjectPage.getInitialProps = async ({ asPath, query, req, res }) => {
 
     if (!projectKitspaceYAML) {
       // If there is not multiproject as specified in the url `{username}/{projectName}/{multiProjectName}`
+      res.statusCode = 404
       return { notFound: true }
     }
 

--- a/frontend/src/pages/[username]/[projectName]/index.js
+++ b/frontend/src/pages/[username]/[projectName]/index.js
@@ -14,11 +14,11 @@ import SharedProjectPage from '@components/SharedProjectPage'
 import { arrayOf, bool, object, string } from 'prop-types'
 import Page from '@components/Page'
 import ProjectCard from '@components/ProjectCard'
-import ErrorPage from '@pages/_error'
+import Custom404 from '@pages/404'
 
 const ProjectPage = props => {
   if (props.notFound) {
-    return <ErrorPage statusCode={404} />
+    return <Custom404 />
   }
 
   if (props?.subProjects)

--- a/frontend/src/pages/_error.js
+++ b/frontend/src/pages/_error.js
@@ -1,13 +1,11 @@
 import React from 'react'
 import { number } from 'prop-types'
 
-import Head from '@components/Head'
 import NavBar from '@components/NavBar'
 import Error from '@components/Error'
 
 const ErrorPage = ({ statusCode }) => (
   <div style={{ maxHeight: '100vh', overflow: 'hidden' }}>
-    <Head />
     <NavBar />
     <Error statusCode={statusCode} />
   </div>


### PR DESCRIPTION
Visiting the Ibom page for nonexistent project returns `500`.