### PR TITLE
Re-enable schematic processing

### DIFF
--- a/processor/README.md
+++ b/processor/README.md
@@ -64,6 +64,7 @@ or
         - `images/top-meta.png`
         - `images/top-with-background.png`
         - `images/layout.svg`
+        - `images/schematic.svg`
         - `1-click-BOM.tsv`
         - `bom-info.json`
         - `interactive_bom.json`
@@ -77,7 +78,7 @@ or
 
 #### POST `/process-file`
 
-- Multi-part form data with an input name of "upload" and a filename that ends with `.kicad_pcb`
+- Multi-part form data with an input name of "upload" and a filename that ends with `.kicad_pcb` or `.sch`
 - Must include a header `Authorization` with contents `Bearer ${KITSPACE_PROCESSOR_REMOTE_API_TOKEN}`
 
 Responds with:
@@ -102,6 +103,7 @@ Responds like "GET `/files/[user]/[project]/[git-ref]/[file]`" above.
 The remote API only supports:
 
 - `images/layout.svg`
+- `images/schematic.svg`
 
 ## Development
 

--- a/processor/src/watcher.js
+++ b/processor/src/watcher.js
@@ -14,6 +14,7 @@ const processPCBQueue = new Queue('processPCB', { connection })
 const processBOMQueue = new Queue('processBOM', { connection })
 const processIBOMQueue = new Queue('processIBOM', { connection })
 const processReadmeQueue = new Queue('processReadme', { connection })
+const processSchematicsQueue = new Queue('processSchematics', { connection })
 
 /**
  *
@@ -133,6 +134,7 @@ function addToQueues(inputDir, kitspaceYaml, outputDir, name, hash) {
     outputDir,
     name,
   })
+  processSchematicsQueue.add('projectAPI', { inputDir, kitspaceYaml, outputDir })
 }
 
 async function getKitspaceYaml(inputDir) {

--- a/processor/test/integration/test_projects.js
+++ b/processor/test/integration/test_projects.js
@@ -20,6 +20,7 @@ const standardProjectFiles = [
   'images/top-meta.png',
   'images/top-with-background.png',
   'images/layout.svg',
+  'images/schematic.svg',
   '1-click-BOM.tsv',
   'interactive_bom.json',
   'gerber-info.json',

--- a/processor/test/integration/test_remote.js
+++ b/processor/test/integration/test_remote.js
@@ -67,6 +67,40 @@ describe('remote API', () => {
     r = await this.supertest.get(layoutSvg).expect(200)
   })
 
+  it('plots schematic.svg', async () => {
+    let r = await this.supertest
+      .post('/process-file')
+      .set('Authorization', `Bearer ${REMOTE_API_TOKEN}`)
+      .attach('upload', path.join(__dirname, 'fixtures/ulx3s.sch'))
+      .expect(202)
+    assert(r.body.id != null)
+    const schematicSvgStatus = `/processed/status/${r.body.id}/images/schematic.svg`
+    const schematicSvg = `/processed/files/${r.body.id}/images/schematic.svg`
+    r = await this.supertest.get(schematicSvgStatus)
+    while (r.body.status === 'in_progress') {
+      r = await this.supertest.get(schematicSvgStatus)
+    }
+    assert(r.body.status === 'done')
+    r = await this.supertest.get(schematicSvg).expect(200)
+  })
+
+  it('plots push-on-hold-off schematic.svg', async () => {
+    let r = await this.supertest
+      .post('/process-file')
+      .set('Authorization', `Bearer ${REMOTE_API_TOKEN}`)
+      .attach('upload', path.join(__dirname, 'fixtures/push-on-hold-off.sch'))
+      .expect(202)
+    assert(r.body.id != null)
+    const schematicSvgStatus = `/processed/status/${r.body.id}/images/schematic.svg`
+    const schematicSvg = `/processed/files/${r.body.id}/images/schematic.svg`
+    r = await this.supertest.get(schematicSvgStatus)
+    while (r.body.status === 'in_progress') {
+      r = await this.supertest.get(schematicSvgStatus)
+    }
+    assert(r.body.status === 'done')
+    r = await this.supertest.get(schematicSvg).expect(200)
+  })
+
   afterEach(async () => {
     await this.app.stop()
     await exec(`rm -rf ${tmpDir}`)


### PR DESCRIPTION
Re-enable schematic.svg output in the processor now that we can set concurrency limits. 
