### PR TITLE
Fix bad substitution error for nginx

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,4 +22,4 @@ MAX_FILE_SIZE=6M
 # The maximum time the migrating repo to gitea can take (in ms),
 # after which the processor will consider the migration a failure
 MAXIMUM_REPO_MIGRATION_TIME=300000
-KITSPACE_ROBOTS_TXT="User-agent: *\\\\nDisallow: \/\\\\n"
+KITSPACE_ROBOTS_TXT="User-agent: *\\\\nDisallow: \\/\\\\n"


### PR DESCRIPTION
I think something about how docker-compose escapes the envs changed. I recently updated to `Docker Compose version 2.3.3` and was getting `sed` errors. Can you check if changing this in your .env breaks your nginx @AbdulrhmnGhanem. 