### PR TITLE
Fix processor running out of memory

### DIFF
--- a/processor/src/app.ts
+++ b/processor/src/app.ts
@@ -6,8 +6,14 @@ import { createRemoteAPI } from './remoteAPI'
 export function createApp(repoDir, checkIsRepoReady) {
   const app = express()
 
+  app.cleanup = []
+
   createProjectsAPI(app, repoDir, checkIsRepoReady)
   createRemoteAPI(app)
+
+  app.stop = async () => {
+    await Promise.all(app.cleanup.map(cleanupFunction => cleanupFunction()))
+  }
 
   return app
 }

--- a/processor/src/app.ts
+++ b/processor/src/app.ts
@@ -3,8 +3,13 @@ import express from 'express'
 import { createProjectsAPI } from './projectAPI'
 import { createRemoteAPI } from './remoteAPI'
 
+interface KitspaceProcessorApp extends express.Express {
+  cleanup?: Array<() => Promise<void>>
+  stop?: () => Promise<void>
+}
+
 export function createApp(repoDir, checkIsRepoReady) {
-  const app = express()
+  const app: KitspaceProcessorApp = express()
 
   app.cleanup = []
 

--- a/processor/src/projectAPI.ts
+++ b/processor/src/projectAPI.ts
@@ -37,8 +37,7 @@ export function createProjectsAPI(app, repoDir, checkIsRepoReady) {
   const unwatch = watcher.watch(repoDir, checkIsRepoReady)
 
   app.cleanup.push(async () => {
-    unwatch()
-    await stopWorkers()
+    await Promise.all([unwatch(), stopWorkers()])
   })
 
   app.get('/status/*', (req, res) => {

--- a/processor/src/projectAPI.ts
+++ b/processor/src/projectAPI.ts
@@ -36,10 +36,10 @@ export function createProjectsAPI(app, repoDir, checkIsRepoReady) {
   const stopWorkers = createWorkers()
   const unwatch = watcher.watch(repoDir, checkIsRepoReady)
 
-  app.stop = async () => {
+  app.cleanup.push(async () => {
     unwatch()
     await stopWorkers()
-  }
+  })
 
   app.get('/status/*', (req, res) => {
     let x = path.relative('/status/', req.path)

--- a/processor/src/remoteAPI.ts
+++ b/processor/src/remoteAPI.ts
@@ -14,16 +14,16 @@ const remoteProcessOutputDir = path.join(DATA_DIR, 'remote-process-public')
 const remoteProcessInputDir = path.join(DATA_DIR, 'remote-process-input-files')
 
 const defaultJobOptions = { removeOnComplete: true }
-const processKicadPCBQueue = new bullmq.Queue('processKicadPCB', {
-  connection,
-  defaultJobOptions,
-})
-const processSchematicsQueue = new bullmq.Queue('processSchematics', {
-  connection,
-  defaultJobOptions,
-})
 
 export function createRemoteAPI(app) {
+  const processKicadPCBQueue = new bullmq.Queue('processKicadPCB', {
+    connection,
+    defaultJobOptions,
+  })
+  const processSchematicsQueue = new bullmq.Queue('processSchematics', {
+    connection,
+    defaultJobOptions,
+  })
   app.use(fileUpload())
 
   const processFileStatus = {}
@@ -129,6 +129,13 @@ export function createRemoteAPI(app) {
       }
     }
     return res.sendStatus(404)
+  })
+
+  app.cleanup.push(async () => {
+    await Promise.all([
+      processKicadPCBQueue.obliterate({ force: true }),
+      processSchematicsQueue.obliterate({ force: true }),
+    ])
   })
 
   return app

--- a/processor/src/remoteAPI.ts
+++ b/processor/src/remoteAPI.ts
@@ -1,10 +1,10 @@
 import * as express from 'express'
 import log from 'loglevel'
 import * as path from 'path'
-import  fileUpload from 'express-fileupload'
-import { Queue } from 'bullmq'
+import fileUpload from 'express-fileupload'
+import * as bullmq from 'bullmq'
 
-import * as utils from './utils'
+import { exec, writeFile } from './utils'
 import events from './events'
 import connection from './redisConnection'
 
@@ -13,8 +13,15 @@ import { DATA_DIR, REMOTE_API_TOKENS } from './env'
 const remoteProcessOutputDir = path.join(DATA_DIR, 'remote-process-public')
 const remoteProcessInputDir = path.join(DATA_DIR, 'remote-process-input-files')
 
-const processKicadPCBQueue = new Queue('processKicadPCB', { connection })
-const processSchematicsQueue = new Queue('processSchematics', { connection })
+const defaultJobOptions = { removeOnComplete: true }
+const processKicadPCBQueue = new bullmq.Queue('processKicadPCB', {
+  connection,
+  defaultJobOptions,
+})
+const processSchematicsQueue = new bullmq.Queue('processSchematics', {
+  connection,
+  defaultJobOptions,
+})
 
 export function createRemoteAPI(app) {
   app.use(fileUpload())
@@ -62,18 +69,26 @@ export function createRemoteAPI(app) {
       }
       const uploadPath = path.join(uploadFolder, upload.md5 + ext)
       const outputDir = path.join(remoteProcessOutputDir, upload.md5)
-      await utils.exec(`mkdir -p ${uploadFolder}`)
-      await utils.writeFile(uploadPath, upload.data).then(() => {
+      await exec(`mkdir -p ${uploadFolder}`)
+      await writeFile(uploadPath, upload.data).then(() => {
         if (ext === '.kicad_pcb') {
-          processKicadPCBQueue.add('remoteAPI', {
-            inputDir: uploadFolder,
-            outputDir,
-          })
+          processKicadPCBQueue.add(
+            'remoteAPI',
+            {
+              inputDir: uploadFolder,
+              outputDir,
+            },
+            { jobId: outputDir },
+          )
         } else if (ext === '.sch') {
-          processSchematicsQueue.add('remoteAPI', {
-            inputDir: uploadFolder,
-            outputDir,
-          })
+          processSchematicsQueue.add(
+            'remoteAPI',
+            {
+              inputDir: uploadFolder,
+              outputDir,
+            },
+            { jobId: outputDir },
+          )
         }
       })
       res.status(202).send({

--- a/processor/src/tasks/processGerbers/index.ts
+++ b/processor/src/tasks/processGerbers/index.ts
@@ -113,21 +113,17 @@ export default async function processGerbers(
         job.updateProgress({ status: 'failed', file: topSvgPath, error }),
       )
 
-    promises.push(
-      generateTopPng(topSvgPath, stackup, topPngPath)
-        .then(() => job.updateProgress({ status: 'done', file: topPngPath }))
-        .catch(error =>
-          job.updateProgress({ status: 'failed', file: topPngPath, error }),
-        ),
-    )
+    await generateTopPng(topSvgPath, stackup, topPngPath)
+      .then(() => job.updateProgress({ status: 'done', file: topPngPath }))
+      .catch(error =>
+        job.updateProgress({ status: 'failed', file: topPngPath, error }),
+      )
 
-    promises.push(
-      generateTopLargePng(topSvgPath, stackup, topLargePngPath)
-        .then(() => job.updateProgress({ status: 'done', file: topLargePngPath }))
-        .catch(error =>
-          job.updateProgress({ status: 'failed', file: topLargePngPath, error }),
-        ),
-    )
+    await generateTopLargePng(topSvgPath, stackup, topLargePngPath)
+      .then(() => job.updateProgress({ status: 'done', file: topLargePngPath }))
+      .catch(error =>
+        job.updateProgress({ status: 'failed', file: topLargePngPath, error }),
+      )
 
     await generateTopMetaPng(topSvgPath, stackup, topMetaPngPath)
       .then(() => job.updateProgress({ status: 'done', file: topMetaPngPath }))
@@ -135,13 +131,11 @@ export default async function processGerbers(
         job.updateProgress({ status: 'failed', file: topMetaPngPath, error }),
       )
 
-    promises.push(
-      generateTopWithBgnd(topMetaPngPath, topWithBgndPath)
-        .then(() => job.updateProgress({ status: 'done', file: topWithBgndPath }))
-        .catch(error =>
-          job.updateProgress({ status: 'failed', file: topWithBgndPath, error }),
-        ),
-    )
+    await generateTopWithBgnd(topMetaPngPath, topWithBgndPath)
+      .then(() => job.updateProgress({ status: 'done', file: topWithBgndPath }))
+      .catch(error =>
+        job.updateProgress({ status: 'failed', file: topWithBgndPath, error }),
+      )
 
     await Promise.all(promises)
   } catch (error) {
@@ -208,7 +202,7 @@ function generateGerberInfo(zipPath, stackup, inputFiles, gerberInfoPath) {
   }
   if (stackup.top.units === 'in') {
     if (stackup.bottom.units !== 'in') {
-      throw new Error('Disparate units in PCB files. Expecting in on bottom.')
+      throw new Error('Disparate units in PCB files. Expecting inches on bottom.')
     }
     gerberInfo.width *= 25.4
     gerberInfo.height *= 25.4

--- a/processor/src/tasks/processGerbers/index.ts
+++ b/processor/src/tasks/processGerbers/index.ts
@@ -113,6 +113,10 @@ export default async function processGerbers(
         job.updateProgress({ status: 'failed', file: topSvgPath, error }),
       )
 
+    // The generate*Png tasks shouldn't run concurrently so we `await` them in
+    // sequence. They all invoke Inkscape and can use a lot of RAM so we run them
+    // one at a time even though they don't depend on each other.
+
     await generateTopPng(topSvgPath, stackup, topPngPath)
       .then(() => job.updateProgress({ status: 'done', file: topPngPath }))
       .catch(error =>

--- a/processor/src/workers.ts
+++ b/processor/src/workers.ts
@@ -9,19 +9,19 @@ import processIBOM from './tasks/processIBOM'
 import processReadme from './tasks/processReadme'
 import events from './events'
 
-const defaultConcurrency = 2
+const defaultConcurrency = 1
 
 type JobProgress = {
-  status: string,
-  file: string,
-  error?: Error,
+  status: string
+  file: string
+  error?: Error
 }
 
 export function createWorkers() {
   const workers = [
     addWorker('writeKitspaceYaml', writeKitspaceYaml),
     addWorker('processKicadPCB', processKicadPCB),
-    addWorker('processSchematics', processSchematics, { concurrency: 1 }),
+    addWorker('processSchematics', processSchematics),
     addWorker('processPCB', processPCB),
     addWorker('processBOM', processBOM),
     addWorker('processIBOM', processIBOM),


### PR DESCRIPTION
Fixes the memory issue of the processor we encountered testing out the d20 project. 

- Uses `jobId` to not start jobs that are already in progress
- Limits worker concurrency to 1 (i.e. no concurrency of an individual worker type)
- Removes concurrency of `inkscape` executions which take up a lot of memory

d20 was now imported without issue on https://review.staging.kitspace.dev/ 

Additionally it now removes/`obliterates` all queues when stopped (which clears out the redis data). This was needed for the integration tests, probably should make use of this when exiting during normal operation as well. 