### PR TITLE
Handle null or blank `multi` key

### DIFF
--- a/frontend/src/pages/[username]/[projectName]/index.js
+++ b/frontend/src/pages/[username]/[projectName]/index.js
@@ -79,7 +79,7 @@ ProjectPage.getInitialProps = async ({ query, req, res }) => {
       canCommit(repoFullname, session?.user?.username),
     ])
 
-    const isMultiProject = kitspaceYAML.hasOwnProperty('multi')
+    const isMultiProject = kitspaceYAML.multi != null
 
     if (isMultiProject && finishedProcessing) {
       const searchResult = await meiliIndex.search('*', {

--- a/frontend/src/utils/projectPage.js
+++ b/frontend/src/utils/projectPage.js
@@ -156,7 +156,7 @@ export const getIsProcessingDone = async assetsPath => {
   }
 
   const kitspaceYAMLBody = await kitspaceYAML.json()
-  const isMultiProject = kitspaceYAMLBody.hasOwnProperty('multi')
+  const isMultiProject = kitspaceYAMLBody.multi != null
 
   if (isMultiProject) {
     const multiProjectsNames = Object.keys(kitspaceYAMLBody.multi)


### PR DESCRIPTION
- Handle the case where `multi` key is set to null or left blank as shown below

```yaml
multi: # Identifier field only used if the repository contains multiple projects. See below for details.
```
