### PR TITLE
Stop running `frontend` and `processor` with root user

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -40,6 +40,7 @@ services:
       dockerfile: Dockerfile
 
   processor:
+    user: root
     build:
       context: processor/
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
       - redis
       - meilisearch
     volumes:
-      - gitea-data:/gitea-data
+      - gitea-data:/gitea-data:ro
       - processor-data:/data
       # share docker daemon when running docker inside docker
       - /var/run/docker.sock:/var/run/docker.sock

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,12 +22,14 @@ COPY yarn.lock .
 RUN yarn --frozen-lockfile
 
 FROM base AS production
-COPY --from=build /build/.next/ .next/
-COPY --from=build /deps/node_modules/ node_modules/
-COPY package.json .
-COPY next.config.js .
-COPY public/ public/
-RUN mkdir src/
-COPY src/server.js src/server.js
-ENV NODE_ENV=production
-CMD yarn start
+COPY --chown=node:node --from=build /build/.next/ .next/
+COPY --chown=node:node --from=build /deps/node_modules/ node_modules/
+COPY --chown=node:node package.json .
+COPY --chown=node:node next.config.js .
+COPY --chown=node:node public/ public/
+RUN mkdir src/ &&  chown -R node src
+COPY --chown=node:node src/server.js src/server.js
+ENV NODE_ENV=productionu
+USER node
+
+CMD ["node", "src/server.js"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -22,14 +22,20 @@ COPY yarn.lock .
 RUN yarn --frozen-lockfile
 
 FROM base AS production
+
+ENV NODE_ENV=production
+# give the node user read-only permissions
+ARG PERMISSION=644
+COPY --chmod=${PERMISSION} --from=build /deps/node_modules/ node_modules/
+COPY --chmod=${PERMISSION} package.json .
+COPY --chmod=${PERMISSION} next.config.js .
+COPY --chmod=${PERMISSION} public/ public/
+COPY --chmod=${PERMISSION} src/server.js server.js
+
+# The `.next` directory is used by `next/image` to cache optimized images.
+# So it needs to be owned by the `node` user.
 COPY --chown=node:node --from=build /build/.next/ .next/
-COPY --chown=node:node --from=build /deps/node_modules/ node_modules/
-COPY --chown=node:node package.json .
-COPY --chown=node:node next.config.js .
-COPY --chown=node:node public/ public/
-RUN mkdir src/ &&  chown -R node src
-COPY --chown=node:node src/server.js src/server.js
-ENV NODE_ENV=productionu
+
 USER node
 
-CMD ["node", "src/server.js"]
+CMD ["node", "server.js"]

--- a/processor/.dockerignore
+++ b/processor/.dockerignore
@@ -2,3 +2,4 @@
 *Dockerfile*
 *docker-compose*
 node_modules
+dist

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -19,14 +19,18 @@ RUN apt-get update -qq && apt-get install -qq --no-install-recommends -y \
     python3-pip \
     git
 
-RUN mkdir /app
 WORKDIR /app
-
 COPY . .
-
 RUN pip3 install -r requirements.txt
 RUN yarn install
 RUN yarn tsc
 RUN yarn cp-assets
 
+RUN addgroup --gid 1000 node && \
+    adduser -u 1000 --gid 1000 node --shell /bin/bash --home /home/node && \
+    mkdir /data /gitea-data && \
+    chown -R node /data /gitea-data
+
+USER node
 CMD ["node", "dist/src/server.js"]
+

--- a/processor/Dockerfile
+++ b/processor/Dockerfile
@@ -33,4 +33,3 @@ RUN addgroup --gid 1000 node && \
 
 USER node
 CMD ["node", "dist/src/server.js"]
-

--- a/scripts/clear_volumes_and_test_processor.sh
+++ b/scripts/clear_volumes_and_test_processor.sh
@@ -20,8 +20,11 @@ docker-compose down -v
 
 # you can pass arguments to mocha e.g. `-g multi`
 args="$(concatenate_args "$@")"
+
+# We need to install packages, compile ts, and move assets before running the actual testing code.
+# The `node` user doesn't have permission to do any of these tasks.
 docker-compose run \
-    -u node \
+    -u root \
     -e LOG_LEVEL=debug \
     -e DATA_DIR=/data/test \
-    processor sh -c "whoami && stat /data /gitea-data /app"
+    processor sh -c "yarn install && yarn tsc && yarn cp-assets && yarn cp-test-assets && yarn test ${args}"

--- a/scripts/clear_volumes_and_test_processor.sh
+++ b/scripts/clear_volumes_and_test_processor.sh
@@ -21,6 +21,7 @@ docker-compose down -v
 # you can pass arguments to mocha e.g. `-g multi`
 args="$(concatenate_args "$@")"
 docker-compose run \
+    -u node \
     -e LOG_LEVEL=debug \
     -e DATA_DIR=/data/test \
-    processor sh -c "yarn install && yarn tsc && yarn cp-assets && yarn cp-test-assets && yarn test ${args}"
+    processor sh -c "whoami && stat /data /gitea-data /app"

--- a/scripts/clear_volumes_and_test_processor.sh
+++ b/scripts/clear_volumes_and_test_processor.sh
@@ -25,6 +25,7 @@ args="$(concatenate_args "$@")"
 # The `node` user doesn't have permission to do any of these tasks.
 docker-compose run \
     -u root \
+    --rm \
     -e LOG_LEVEL=debug \
     -e DATA_DIR=/data/test \
     processor sh -c "yarn install && yarn tsc && yarn cp-assets && yarn cp-test-assets && yarn test ${args}"


### PR DESCRIPTION
While investigating #450 I noticed the server runs as `root` which can lead to [some issues](https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/security/non-root-user.md).