### PR TITLE
Remove next-composition

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,6 @@
     "meilisearch": "^0.25.1",
     "morgan": "^1.10.0",
     "next": "^12.1.6",
-    "next-composition": "^1.0.0",
     "node-fetch": "2",
     "prop-types": "^15.7.2",
     "raw-loader": "^4.0.0",

--- a/frontend/src/pages/login/index.jsx
+++ b/frontend/src/pages/login/index.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useContext } from 'react'
-import { composeServerSideProps } from 'next-composition'
 import { func } from 'prop-types'
 import { useRouter } from 'next/router'
 import {
@@ -63,9 +62,7 @@ const Login = () => {
   )
 }
 
-export const getServerSideProps = composeServerSideProps({
-  use: [withAlreadySignedIn],
-})
+export const getServerSideProps = withAlreadySignedIn
 
 const SignInForm = () => {
   const endpoint = `${KITSPACE_GITEA_URL}/user/kitspace/sign_in`

--- a/frontend/src/pages/projects/new/index.jsx
+++ b/frontend/src/pages/projects/new/index.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from 'react'
-import { composeServerSideProps } from 'next-composition'
 import { Grid, Divider } from 'semantic-ui-react'
 
 import { NoOp, SyncOp, UploadOp } from '@components/NewProject/Ops'
@@ -72,8 +71,6 @@ const New = () => {
   )
 }
 
-export const getServerSideProps = composeServerSideProps({
-  use: [withRequireSignIn('/projects/new')],
-})
+export const getServerSideProps = withRequireSignIn('/projects/new')
 
 export default New

--- a/frontend/src/pages/settings.jsx
+++ b/frontend/src/pages/settings.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import { composeServerSideProps } from 'next-composition'
 
 import { withRequireSignIn } from '@utils/authHandlers'
 import Page from '@components/Page'
@@ -12,8 +11,6 @@ const Settings = () => {
   )
 }
 
-export const getServerSideProps = composeServerSideProps({
-  use: [withRequireSignIn('/settings')],
-})
+export const getServerSideProps = withRequireSignIn('/settings')
 
 export default Settings

--- a/frontend/src/utils/authHandlers.js
+++ b/frontend/src/utils/authHandlers.js
@@ -15,13 +15,14 @@ export const withRequireSignIn =
     const isRelativePath = asPath.startsWith('/')
     if (!isAuthenticated(session) && isRelativePath) {
       return {
+        props: {},
         redirect: {
           destination: `/login?redirect=${encodeURIComponent(asPath)}`,
           permanent: false,
         },
       }
     }
-    return {}
+    return { props: {} }
   }
 
 /**
@@ -37,6 +38,7 @@ export const withAlreadySignedIn = ({ req }) => {
     // Only redirect if it belongs to our website.
     if (redirect.startsWith('/')) {
       return {
+        props: {},
         redirect: {
           destination: redirect,
           permanent: false,
@@ -44,7 +46,7 @@ export const withAlreadySignedIn = ({ req }) => {
       }
     }
   }
-  return {}
+  return { props: {} }
 }
 
 const isAuthenticated = session => session?.user != null

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2984,11 +2984,6 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-next-composition@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/next-composition/-/next-composition-1.0.0.tgz#201afeadb3da9ae9b42eb649d715eebf1f062303"
-  integrity sha512-HqKFxjLarMUSVCU1KVcgIUUu7deQ13uruaofItWx1LgfyM81cqTMrTGTcnKEhBU+3KXNSgiciWB1XoaFExoYmA==
-
 next@^12.1.6:
   version "12.1.6"
   resolved "https://registry.yarnpkg.com/next/-/next-12.1.6.tgz#eb205e64af1998651f96f9df44556d47d8bbc533"


### PR DESCRIPTION
I blew away the lockfile for some experiments with using pnpm and noticed `next-composition` has a breaking change 1.0 -> 1.1 (it stops returning  empty`{props: {}}` by default). I also noticed that we aren't really using it for anything useful and it's making the code less clear. Hence I am removing it. 