### PR TITLE
Fix e2e names and emails and make validation rules for `Sign{Up,In}Form` match gitea

### DIFF
--- a/e2e/cypress/integration/IBOM.spec.js
+++ b/e2e/cypress/integration/IBOM.spec.js
@@ -1,6 +1,4 @@
-import faker from 'faker'
-
-import { getFakeUsername } from '../support/getFakeUsername'
+import { getFakeUser } from '../support/getFakeUser'
 
 describe('IBOM page', () => {
   before(() => {
@@ -12,9 +10,7 @@ describe('IBOM page', () => {
   })
 
   it('should redirect to project page (multi project)', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.createUser(username, email, password)
     cy.visit('/')
@@ -58,9 +54,7 @@ describe('IBOM page', () => {
   })
 
   it('should redirect to the project page (normal project)', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.createUser(username, email, password)
     cy.visit('/')
@@ -95,9 +89,7 @@ describe('IBOM page', () => {
   })
 
   it('should not render `Assembly Guide` button for projects with `ibom-enabled: false', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
     cy.createUser(username, email, password)
     cy.visit('/')
     cy.get('[data-cy=user-menu]')

--- a/e2e/cypress/integration/IBOM.visual.spec.js
+++ b/e2e/cypress/integration/IBOM.visual.spec.js
@@ -1,12 +1,8 @@
-import faker from 'faker'
-
-import { getFakeUsername } from '../support/getFakeUsername'
+import { getFakeUser } from '../support/getFakeUser'
 
 describe.skip('Regression test for IBOM ', () => {
   before(() => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'CH330_Hardware'
     const syncedRepoUrl = 'https://github.com/kitspace-test-repos/CH330_Hardware'

--- a/e2e/cypress/integration/authRedirects.spec.js
+++ b/e2e/cypress/integration/authRedirects.spec.js
@@ -1,11 +1,7 @@
-import faker from 'faker'
-
-import { getFakeUsername } from '../support/getFakeUsername'
+import { getFakeUser } from '../support/getFakeUser'
 
 describe('Authentication redirects', () => {
-  const username = getFakeUsername()
-  const email = faker.unique(faker.internet.email)
-  const password = '123456'
+  const { username, email, password } = getFakeUser()
 
   before(() => {
     /*
@@ -51,9 +47,7 @@ describe('Authentication redirects', () => {
 })
 
 describe('Redirect after login', () => {
-  const username = getFakeUsername()
-  const email = faker.unique(faker.internet.email)
-  const password = '123456'
+  const { username, email, password } = getFakeUser()
 
   before(() => {
     cy.visit('/')
@@ -102,9 +96,7 @@ describe('Redirect after login', () => {
 describe('Redirect after sign-up', () => {
   it('should redirect to homepage if there is no redirect query', () => {
     // sign the user up
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.visit('/login')
     cy.signUp(username, email, password)
@@ -117,9 +109,7 @@ describe('Redirect after sign-up', () => {
     const pageClickFrom = 'projects/new'
     cy.visit(pageClickFrom)
     // sign the user up
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.signUp(username, email, password)
 
@@ -135,9 +125,7 @@ describe('Redirect after sign-up', () => {
     cy.get('[data-cy=login-grid]').should('be.visible')
 
     // sign the user up
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
     cy.signUp(username, email, password)
 
     cy.url().should('eq', `http://kitspace.test:3000${requireSignInPage}`)
@@ -147,9 +135,7 @@ describe('Redirect after sign-up', () => {
 
 describe('Redirect after logout', () => {
   it('should redirect to login page', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
     cy.createUser(username, email, password)
 
     // Press the logout button
@@ -162,9 +148,7 @@ describe('Redirect after logout', () => {
 })
 
 describe('"Add Project" behavior', () => {
-  const username = getFakeUsername()
-  const email = faker.unique(faker.internet.email)
-  const password = '123456'
+  const { username, email, password } = getFakeUser()
 
   before(() => {
     cy.visit('/')
@@ -185,9 +169,7 @@ describe('"Add Project" behavior', () => {
     // and adds redirect query to `/projects/new/`
     cy.get('#add_project').click()
 
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
     cy.createUser(username, email, password)
     cy.url().should('eq', 'http://kitspace.test:3000/projects/new')
   })

--- a/e2e/cypress/integration/multiProject.spec.js
+++ b/e2e/cypress/integration/multiProject.spec.js
@@ -1,6 +1,4 @@
-import faker from 'faker'
-
-import { getFakeUsername } from '../support/getFakeUsername'
+import { getFakeUser } from '../support/getFakeUser'
 
 const syncedRepoUrlMultiProjects =
   'https://github.com/kitspace-test-repos/DIY_particle_detector'
@@ -19,9 +17,7 @@ describe('Render project cards', () => {
   })
 
   it('should render a card for each multiproject', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = syncedRepoUrlMultiProjects.split('/').slice(-1).toString()
 
@@ -52,9 +48,7 @@ describe('Render project cards', () => {
   })
 
   it('should display card thumbnail', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.createUser(username, email, password)
     cy.visit('/')
@@ -96,9 +90,7 @@ describe('Render project cards', () => {
   })
 
   it('should redirect to the multi project page', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.createUser(username, email, password)
     cy.visit('/')
@@ -142,9 +134,7 @@ describe('Render project cards', () => {
   })
 
   it('should handle subproject names with URL invalid characters', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.createUser(username, email, password)
     cy.visit('/')
@@ -187,9 +177,7 @@ describe('Multi project page', () => {
   })
 
   it('should render the page components', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.createUser(username, email, password)
     cy.visit('/')
@@ -238,9 +226,7 @@ describe('Multi project page', () => {
   })
 
   it('should render the details from multi project in kitspace.yaml', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.createUser(username, email, password)
     cy.visit('/')

--- a/e2e/cypress/integration/readme.spec.js
+++ b/e2e/cypress/integration/readme.spec.js
@@ -1,6 +1,4 @@
-import faker from 'faker'
-
-import { getFakeUsername } from '../support/getFakeUsername'
+import { getFakeUser } from '../support/getFakeUser'
 
 describe('Relative README images URLs normalization', () => {
   before(() => {
@@ -12,9 +10,7 @@ describe('Relative README images URLs normalization', () => {
   })
 
   it('should be able to fetch relative README image', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'CH330_Hardware'
     const syncedRepoUrl = 'https://github.com/kitspace-test-repos/CH330_Hardware'
@@ -46,9 +42,7 @@ describe('Relative README images URLs normalization', () => {
   })
 
   it('handles readmes in folders', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'readmes-in-folders'
     const syncedRepoUrl =
@@ -84,9 +78,7 @@ describe('Relative README images URLs normalization', () => {
   })
 
   it('redirects relative urls to original git service', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'readmes-in-folders'
     const syncedRepoUrl =
@@ -118,9 +110,7 @@ describe('Relative README images URLs normalization', () => {
 
 describe('Readme style', () => {
   it('should auto link readme and summary links', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'readme-and-summary-auto-link'
     const syncedRepoUrl =
@@ -159,9 +149,7 @@ describe('Readme style', () => {
   })
 
   it('renders :emoji: in readme and project description', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'ogx360'
     const syncedRepoUrl = 'https://github.com/kitspace-test-repos/ogx360'
@@ -187,9 +175,7 @@ describe('Readme style', () => {
   })
 
   it('preserves URLs for GitHub Actions badges', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'ogx360'
     const syncedRepoUrl = 'https://github.com/kitspace-test-repos/ogx360'

--- a/e2e/cypress/integration/search.spec.js
+++ b/e2e/cypress/integration/search.spec.js
@@ -1,6 +1,4 @@
-import faker from 'faker'
-
-import { getFakeUsername } from '../support/getFakeUsername'
+import { getFakeUser } from '../support/getFakeUser'
 
 describe('Homepage search bar', () => {
   it('should redirect to /search when search is submitted', () => {
@@ -19,9 +17,7 @@ describe('Homepage search bar', () => {
   })
 
   it('should display project card on submitting search form', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'CH330_Hardware'
     const syncedRepoUrl = 'https://github.com/kitspace-test-repos/CH330_Hardware'
@@ -64,9 +60,7 @@ describe('Search', () => {
   })
 
   it('should use `q` from query parameters', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'HACK'
     const syncedRepoUrl = 'https://github.com/kitspace-test-repos/HACK'

--- a/e2e/cypress/integration/signInForm.spec.js
+++ b/e2e/cypress/integration/signInForm.spec.js
@@ -8,7 +8,7 @@ describe('Log in form validation', () => {
     cy.get('[data-cy=login-grid] a').contains('Login').click({ force: true })
   })
   it('should validate username field', () => {
-    const invalidUsernames = ['abc ', 'abc@', ' ', '^', 'ZqFe3jOudI7DuBOJ1wyXT']
+    const invalidUsernames = ['abc ', 'abc@', ' ', '^', 'longusername'.repeat(4)]
 
     // Type the password to make sure we're validating the username only
     cy.get('input[name=password]').type('123456')
@@ -21,7 +21,11 @@ describe('Log in form validation', () => {
       cy.get('@message').should('be.visible')
 
       // The error message should indicate that the username is invalid.
-      cy.get('@message').should('include.text', 'Invalid username or email')
+      cy.get('@message')
+        .contains(
+          /Invalid "username"\. Username must contain only letters, numbers, "_", "-", and "\."|"username" length must be less than or equal to 40 characters long/g,
+        )
+        .should('be.visible')
 
       // Login button should stay disabled
       cy.get('button').contains('Login').should('be.disabled')

--- a/e2e/cypress/integration/signInForm.spec.js
+++ b/e2e/cypress/integration/signInForm.spec.js
@@ -1,6 +1,6 @@
 import faker from 'faker'
 
-import { getFakeUsername } from '../support/getFakeUsername'
+import { getFakeUser } from '../support/getFakeUser'
 
 describe('Log in form validation', () => {
   before(() => {
@@ -30,9 +30,7 @@ describe('Log in form validation', () => {
 })
 
 describe('Log in form submission', () => {
-  const username = getFakeUsername()
-  const email = faker.unique(faker.internet.email)
-  const password = '123456'
+  const { username, email, password } = getFakeUser()
 
   before(() => {
     // create user and log him in.

--- a/e2e/cypress/integration/signUpForm.spec.js
+++ b/e2e/cypress/integration/signUpForm.spec.js
@@ -1,6 +1,4 @@
-import faker from 'faker'
-
-import { getFakeUsername } from '../support/getFakeUsername'
+import { getFakeUser } from '../support/getFakeUser'
 
 describe('Sign up form validation', () => {
   before(() => {
@@ -69,9 +67,7 @@ describe('Sign up form validation', () => {
 })
 
 describe('Sign up form submission', () => {
-  const username = getFakeUsername()
-  const email = faker.unique(faker.internet.email)
-  const password = '123456'
+  const { username, email, password } = getFakeUser()
 
   before(() => {
     /*
@@ -92,11 +88,9 @@ describe('Sign up form submission', () => {
   })
 
   it('should automatically sign the user in after submitting a valid form', () => {
-    const newUsername = getFakeUsername()
-    const newEmail = faker.unique(faker.internet.email)
-    const newPassword = '123456'
+    const { username, email, password } = getFakeUser()
 
-    cy.signUp(newUsername, newEmail, newPassword)
+    cy.signUp(username, email, password)
 
     // the user should be signed in
     cy.get('[data-cy=user-menu]').should('be.visible')

--- a/e2e/cypress/integration/signUpForm.spec.js
+++ b/e2e/cypress/integration/signUpForm.spec.js
@@ -18,21 +18,18 @@ describe('Sign up form validation', () => {
 
   it('should display error message on using invalid username', () => {
     // Try different invalid usernames.
-    const invalidUsernames = [
-      'a_b',
-      'abc ',
-      'abc@',
-      ' ',
-      '^',
-      'ZqFe3jOudI7DuBOJ1wyXT',
-    ]
+    const invalidUsernames = ['abc ', 'abc@', ' ', '^', 'longusername'.repeat(4)]
 
     invalidUsernames.forEach(username => {
       cy.get('input[name=username]').clear().type(username).blur()
 
       // The error message should indicate that the username is invalid.
       cy.get('.prompt.label').as('message')
-      cy.get('@message').should('be.visible')
+      cy.get('@message')
+        .contains(
+          /Invalid "username"\. Username must contain only letters, numbers, "_", "-", and "\."|"username" length must be less than or equal to 40 characters long|"username" length must be at least 2 characters long/g,
+        )
+        .should('be.visible')
       cy.get('@message').should('include.text', '"username"')
     })
   })
@@ -49,7 +46,7 @@ describe('Sign up form validation', () => {
       // The error message should indicate that the email is invalid.
       cy.get('.prompt.label').as('message')
       cy.get('@message').should('be.visible')
-      cy.get('@message').should('include.text', '"email"')
+      cy.get('@message').should('include.text', 'Invalid email address')
     })
   })
 

--- a/e2e/cypress/integration/syncRepo.spec.js
+++ b/e2e/cypress/integration/syncRepo.spec.js
@@ -1,6 +1,4 @@
-import faker from 'faker'
-
-import { getFakeUsername } from '../support/getFakeUsername'
+import { getFakeUser } from '../support/getFakeUser'
 
 describe('Syncing a project behavior validation', () => {
   before(() => {
@@ -15,9 +13,7 @@ describe('Syncing a project behavior validation', () => {
     const syncedRepoUrl = 'https://github.com/AbdulrhmnGhanem/light-test-repo'
     const repoName = 'light-test-repo'
 
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.createUser(username, email, password)
     cy.visit('/')
@@ -38,9 +34,7 @@ describe('Syncing a project behavior validation', () => {
   })
 
   it('should display original url for synced repos', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'CH330_Hardware'
     const syncedRepoUrl = 'https://github.com/kitspace-test-repos/CH330_Hardware'
@@ -68,9 +62,7 @@ describe('Syncing a project behavior validation', () => {
   })
 
   it.skip('should fall back to repo description on missing `summary` key in `kitspace.yaml`', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'ArduTouch'
     const syncedRepoUrl = 'https://github.com/kitspace-test-repos/ArduTouch'
@@ -95,9 +87,7 @@ describe('Syncing a project behavior validation', () => {
   })
 
   it.skip('should fall back to repo description in `ProjectCard` on missing `summary` in `kitspace.yaml', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'CH330_Hardware_without_summary'
     const syncedRepoUrl =
@@ -129,9 +119,7 @@ describe('Syncing a project behavior validation', () => {
   })
 
   it.skip('should escape and render project description correctly', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     const repoName = 'LED-Zappelin'
     const syncedRepoUrl = 'https://github.com/kitspace-test-repos/LED-Zappelin'

--- a/e2e/cypress/integration/uploadProject.spec.js
+++ b/e2e/cypress/integration/uploadProject.spec.js
@@ -1,6 +1,4 @@
-import faker from 'faker'
-
-import { getFakeUsername } from '../support/getFakeUsername'
+import { getFakeUser } from '../support/getFakeUser'
 
 describe('Upload project', () => {
   before(() => {
@@ -12,9 +10,7 @@ describe('Upload project', () => {
   })
 
   it('should create a project and redirect to its update route on file drop', () => {
-    const username = getFakeUsername()
-    const email = faker.unique(faker.internet.email)
-    const password = '123456'
+    const { username, email, password } = getFakeUser()
 
     cy.createUser(username, email, password)
     cy.visit('/')
@@ -36,9 +32,7 @@ describe('Upload project', () => {
 })
 
 describe('User projects name collision', () => {
-  const username = getFakeUsername()
-  const email = faker.internet.email()
-  const password = '123456'
+  const { username, email, password } = getFakeUser()
 
   before(() => {
     /*

--- a/e2e/cypress/support/getFakeUser.js
+++ b/e2e/cypress/support/getFakeUser.js
@@ -2,18 +2,22 @@ import faker from 'faker'
 
 /**
  * `faker.unique` isn't that unique; sometimes it returns a previously used username.
- * @returns {string} unique username
+ * @returns {{username: string, email: string, password: string}}}}}
  */
-export const getFakeUsername = () => {
+export const getFakeUser = () => {
   let username
   try {
     // It might fail to find unique username in the specified `maxTime`
-    username = faker.unique(faker.name.firstName, undefined, { maxTime: 50 })
+    username = faker.unique(faker.internet.userName, undefined, { maxTime: 50 })
   } catch (e) {
-    username = faker.name.firstName()
+    username = faker.internet.userName()
   }
   // This will make probability of returning the same username 1/1000 of the `faker.unique`.
   const suffix = (Math.random() * 1_000).toFixed()
 
-  return `${username}${suffix}`
+  return {
+    email: `${username}@example.com`,
+    password: 'password',
+    username: `${username}${suffix}`,
+  }
 }

--- a/frontend/src/hooks/useForm.ts
+++ b/frontend/src/hooks/useForm.ts
@@ -101,7 +101,8 @@ const validate = (form, schema) => {
 
   const allErrors = {}
   for (const errorField of details) {
-    allErrors[errorField.context.key] = errorField.message
+    allErrors[errorField.context.key] =
+      errorField.context.message ?? errorField.message
   }
 
   return allErrors

--- a/frontend/src/models/SignInForm.js
+++ b/frontend/src/models/SignInForm.js
@@ -2,13 +2,26 @@ import Joi from 'joi'
 
 const SignInFormModel = Joi.object({
   _csrf: Joi.string(),
-  username: Joi.string()
-    .regex(/^(?:[A-Z\d][A-Z\d_-]{0,19}|[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4})$/i)
-    .required()
-    .messages({
-      'string.pattern.base': 'Invalid username or email',
-    }),
+  username: Joi.alternatives()
+    .try(
+      Joi.string()
+        .regex(/^[a-zA-Z0-9_.-]+$/, 'username')
+        .min(2)
+        .max(40)
+        .messages({
+          'string.pattern.name':
+            'Invalid "username". Username must contain only letters, numbers, "_", "-", and "."',
+        }),
+
+      Joi.string()
+        .regex(/^([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4})$/i, 'email')
+        .messages({
+          'string.pattern.name': 'Invalid email address',
+        }),
+    )
+    .required(),
   password: Joi.string().required(),
 })
 
 export default SignInFormModel
+// regex to match email

--- a/frontend/src/models/SignUpForm.js
+++ b/frontend/src/models/SignUpForm.js
@@ -2,9 +2,19 @@ import Joi from 'joi'
 
 const SignUpFormModel = Joi.object({
   _csrf: Joi.string(),
-  username: Joi.string().alphanum().required().max(20),
+  username: Joi.string()
+    .regex(/^[a-zA-Z0-9_.-]+$/, 'username')
+    .min(2)
+    .max(40)
+    .messages({
+      'string.pattern.name':
+        'Invalid "username". Username must contain only letters, numbers, "_", "-", and ".".',
+    }),
   email: Joi.string()
-    .email({ tlds: { allow: false } })
+    .regex(/^([A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,4})$/i, 'email')
+    .messages({
+      'string.pattern.name': 'Invalid email address',
+    })
     .required(),
   password: Joi.string().min(6).required(),
 })


### PR DESCRIPTION
- e2e: use faker `userName` instead of `firstName` and @example emails.
- Make validation rules for `Sign{Up,In}Form` match gitea.
##
Fixes #482 and closes #481
