### PR TITLE
Remove styled-jsx

### DIFF
--- a/e2e/cypress/integration/authRedirects.spec.js
+++ b/e2e/cypress/integration/authRedirects.spec.js
@@ -29,7 +29,7 @@ describe('Authentication redirects', () => {
     cy.clearCookies()
     cy.forceVisit('/')
     // navigate to `/projects/new`with client-side interactions.
-    cy.get('#add-project').click({ timeout: 10000 })
+    cy.get('[data-cy=add-project]').click({ timeout: 10000 })
     // `/project/new` is marked as require sign in.
     cy.get('[data-cy=login-grid]').should('be.visible')
   })

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,6 @@
     "react-social-login-buttons": "3.1.2",
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^2.0.3",
-    "styled-jsx": "^5.0.0",
     "swr": "^1.3.0",
     "url-loader": "^4.1.0",
     "webpack": "^5.0.0"

--- a/frontend/src/components/Board/Readme.jsx
+++ b/frontend/src/components/Board/Readme.jsx
@@ -7,7 +7,6 @@ const Readme = ({ renderedReadme }) => (
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: renderedReadme }}
     />
-    {/* <style global jsx>{``}</style> */}
   </div>
 )
 

--- a/frontend/src/components/Board/Readme.jsx
+++ b/frontend/src/components/Board/Readme.jsx
@@ -7,62 +7,7 @@ const Readme = ({ renderedReadme }) => (
       // eslint-disable-next-line react/no-danger
       dangerouslySetInnerHTML={{ __html: renderedReadme }}
     />
-    <style global jsx>{`
-      #readme {
-        margin: 2rem 0;
-        padding: 0.8rem;
-        border-radius: 5px;
-        border: 1px solid #eeeeee;
-      }
-      #readme > div {
-        max-width: 1000px;
-      }
-      #readme img {
-        max-width: 100%;
-      }
-
-      #readme pre {
-        overflow-x: auto;
-      }
-
-      #readme code,
-      #readme .highlight {
-        padding: 0.2em 0.4em 0.2em 0.4em;
-        margin: 0;
-        font-size: 85%;
-        background-color: rgba(0, 0, 0, 0.04);
-        border-radius: 3px;
-      }
-
-      #readme input[type='checkbox'] {
-        margin-right: 5px;
-      }
-
-      #readme table {
-        border-collapse: collapse;
-        border-spacing: 0;
-        display: block;
-        max-width: 100%;
-        overflow: auto;
-        width: 100%;
-        width: max-content;
-      }
-
-      #readme table tr {
-        background-color: #ffffff;
-        border-top: 1px solid hsla(210, 18%, 91%, 1);
-      }
-
-      #readme table th,
-      #readme table td {
-        padding: 6px 13px;
-        border: 1px solid #d0d7de;
-      }
-
-      #readme table tr:nth-child(2n) {
-        background-color: #f6f8fa;
-      }
-    `}</style>
+    {/* <style global jsx>{``}</style> */}
   </div>
 )
 

--- a/frontend/src/components/Board/readme.module.scss
+++ b/frontend/src/components/Board/readme.module.scss
@@ -1,0 +1,59 @@
+/*
+ * We are keeping this file here to keep it closer to the component that uses it.
+ * We import it in _app.scss because we can't apply global style in *.module.scss files.
+*/
+
+#readme {
+  margin: 2rem 0;
+  padding: 0.8rem;
+  border-radius: 5px;
+  border: 1px solid #eeeeee;
+}
+#readme > div {
+  max-width: 1000px;
+}
+#readme img {
+  max-width: 100%;
+}
+
+#readme pre {
+  overflow-x: auto;
+}
+
+#readme code,
+#readme .highlight {
+  padding: 0.2em 0.4em 0.2em 0.4em;
+  margin: 0;
+  font-size: 85%;
+  background-color: rgba(0, 0, 0, 0.04);
+  border-radius: 3px;
+}
+
+#readme input[type='checkbox'] {
+  margin-right: 5px;
+}
+
+#readme table {
+  border-collapse: collapse;
+  border-spacing: 0;
+  display: block;
+  max-width: 100%;
+  overflow: auto;
+  width: 100%;
+  width: max-content;
+}
+
+#readme table tr {
+  background-color: #ffffff;
+  border-top: 1px solid hsla(210, 18%, 91%, 1);
+}
+
+#readme table th,
+#readme table td {
+  padding: 6px 13px;
+  border: 1px solid #d0d7de;
+}
+
+#readme table tr:nth-child(2n) {
+  background-color: #f6f8fa;
+}

--- a/frontend/src/components/NavBar/fixNavBarAlignment.module.scss
+++ b/frontend/src/components/NavBar/fixNavBarAlignment.module.scss
@@ -1,5 +1,7 @@
-// We are keeping this file here to keep it closer to the component that uses it.
-// We import it in _app.scss because we can't apply global style in *.module.scss files.
+/*
+ * We are keeping this file here to keep it closer to the component that uses it.
+ * We import it in _app.scss because we can't apply global style in *.module.scss files.
+*/
 
 #nav div .menu :is(a, div).item {
   // Align menu items with the search bar vertically.

--- a/frontend/src/components/NavBar/fixNavBarAlignment.module.scss
+++ b/frontend/src/components/NavBar/fixNavBarAlignment.module.scss
@@ -1,0 +1,7 @@
+// We are keeping this file here to keep it closer to the component that uses it.
+// We import it in _app.scss because we can't apply global style in *.module.scss files.
+
+#nav div .menu :is(a, div).item {
+  // Align menu items with the search bar vertically.
+  align-self: center;
+}

--- a/frontend/src/components/NavBar/index.jsx
+++ b/frontend/src/components/NavBar/index.jsx
@@ -120,12 +120,6 @@ const SiteMenuItems = () => {
       <Menu.Item className={styles.SearchBarContainer}>
         <SearchBar />
       </Menu.Item>
-      {/* Align menu items with the search bar vertically. */}
-      <style global jsx>{`
-        #nav div .menu :is(a, div).item {
-          align-self: center;
-        }
-      `}</style>
     </>
   )
 }

--- a/frontend/src/components/NavBar/index.jsx
+++ b/frontend/src/components/NavBar/index.jsx
@@ -51,7 +51,7 @@ const BigBar = () => (
 
 const SmallBar = () => (
   /* This is the Navbar render on small screens */
-  <div className={styles.smallMenu}>
+  <div className={styles.smallNavBar}>
     <Logo />
     <Popup
       basic
@@ -64,29 +64,19 @@ const SmallBar = () => (
         </Button>
       }
     >
-      <Menu inverted vertical id="small-menu">
+      <Menu inverted vertical className={styles.smallMenu}>
         <UserControllerButton smallNavBar />
         <AddProjectButton />
         <SiteMenuItems />
         <SocialMenuItems />
       </Menu>
-      {
-        /* Add a separation line after user specific actions.*/
-        <style global jsx>{`
-          #small-menu #projects:before {
-            background-color: white;
-            height: 1px;
-            margin-bottom: 30px;
-          }
-        `}</style>
-      }
     </Popup>
   </div>
 )
 
 const AddProjectButton = () => {
   return (
-    <Menu.Item id="add-project">
+    <Menu.Item className={styles.addProject} data-cy="add-project">
       <Link passHref href="/projects/new">
         <Button icon as="a" color="green" id="add_project" labelPosition="left">
           <Icon name="plus" />
@@ -107,7 +97,13 @@ const SiteMenuItems = () => {
   return (
     <>
       <Link passHref href="/">
-        <Menu.Item active={isProjectRoute} as="a" id="projects">
+        <Menu.Item
+          active={isProjectRoute}
+          as="a"
+          // Add a separation line after user specific actions.
+          className={styles.projects}
+          href="/"
+        >
           Projects
         </Menu.Item>
       </Link>
@@ -209,7 +205,7 @@ const LogInButton = () => {
   }
 
   return (
-    <Menu.Item>
+    <Menu.Item className={styles.LogInButton}>
       <Link passHref href={href}>
         <Button as="a" color="green" id="login">
           Login

--- a/frontend/src/components/NavBar/index.module.scss
+++ b/frontend/src/components/NavBar/index.module.scss
@@ -60,7 +60,7 @@
   cursor: pointer;
 }
 
-.submissionButton {
+.addProject {
   align-items: center;
   background: $fruit-salad;
   border: 0;
@@ -87,12 +87,26 @@
   margin-right: 8px;
 }
 
-.smallMenu {
+.smallMenu .projects:before {
+  /* Add a separation line after user specific actions.*/
+  background-color: white !important;
+  height: 1px !important;
+  margin-bottom: 30px !important;
+}
+
+.smallNavBar {
   display: none;
   @include breakpoint(mobile_menu) {
     display: flex;
     justify-content: space-around;
     width: 90%;
+  }
+}
+
+.LogInButton {
+  @include breakpoint(mobile_menu) {
+    display: flex !important;
+    justify-content: center;
   }
 }
 

--- a/frontend/src/pages/_app.scss
+++ b/frontend/src/pages/_app.scss
@@ -1,5 +1,6 @@
 @import 'highlight.js/styles/default.css';
 @import '../components/colors';
+@import '../components/NavBar/fixNavBarAlignment.module.scss';
 
 html,
 head,

--- a/frontend/src/pages/_app.scss
+++ b/frontend/src/pages/_app.scss
@@ -1,6 +1,7 @@
 @import 'highlight.js/styles/default.css';
 @import '../components/colors';
 @import '../components/NavBar/fixNavBarAlignment.module.scss';
+@import '../components/Board/readme.module.scss';
 
 html,
 head,

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4051,11 +4051,6 @@ styled-jsx@5.0.2:
   resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.2.tgz#ff230fd593b737e9e68b630a694d460425478729"
   integrity sha512-LqPQrbBh3egD57NBcHET4qcgshPks+yblyhPlH2GY8oaDgKs8SK4C3dBh3oSJjgzJ3G5t1SYEZGHkP+QEpX9EQ==
 
-styled-jsx@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-5.0.0.tgz#816b4b92e07b1786c6b7111821750e0ba4d26e77"
-  integrity sha512-qUqsWoBquEdERe10EW8vLp3jT25s/ssG1/qX5gZ4wu15OZpmSMFI2v+fWlRhLfykA5rFtlJ1ME8A8pm/peV4WA==
-
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"


### PR DESCRIPTION
- Refactor: move SmallMenu style into its SCSS module
- Refactor: replace styled-jsx with scss file for items alignment
- Refactor: replace styled-jsx with scss file for readme
- Deps: remove styled-jsx
##
|before (menu)|after (menu)|
|---|---|
|![image](https://user-images.githubusercontent.com/37152329/201411367-146118a8-f76e-46b4-a2d5-d75dd95413da.png)|![image](https://user-images.githubusercontent.com/37152329/201411506-227d3d30-91cd-48e4-a6b0-ff0bae962073.png)|

|before (readme)|after (readme)|
|---|---|
|![image](https://user-images.githubusercontent.com/37152329/201412150-e095f5dd-d800-4000-b999-e514e76371cc.png)|![image](https://user-images.githubusercontent.com/37152329/201412431-04d31af2-a8d0-475a-a0a1-590c95d1d0b5.png)|

##
Closes #269.
