### PR TITLE
Tag docker images with branch name instead of "latest"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -307,21 +307,20 @@ jobs:
           docker-compose -f docker-compose.yml -f docker-compose.deploy.yml -f docker-compose.e2e.yml up \
             --abort-on-container-exit --exit-code-from e2e
 
-  publish:
-    name: Tag "latest"
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-    runs-on: ubuntu-20.04
+  tag_docker_images:
+    if: ${{ github.event_name == 'push' }}
+    name: Tag with branch name
+    runs-on: ubuntu-22.04
     needs:
       - get_version
       - build
-      - test
     strategy:
       fail-fast: false
       matrix:
         service: [frontend, processor, nginx, gitea]
 
     steps:
-      - name: Tag ${{ matrix.service }}:latest
+      - name: Tag '${{ matrix.service }}:${{ github.ref_name }}'
         run: |
           case '${{ matrix.service }}' in
             frontend)
@@ -339,8 +338,7 @@ jobs:
             -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
             > manifest.json
           curl -X PUT \
-            https://ghcr.io/v2/kitspace/${{ matrix.service }}/manifests/latest \
+            https://ghcr.io/v2/kitspace/${{ matrix.service }}/manifests/${{ github.ref_name }} \
             -H "Authorization: Bearer $(echo '${{ secrets.GITHUB_TOKEN }}' | base64)"  \
             -H "Content-Type: application/vnd.docker.distribution.manifest.v2+json" \
             -d '@manifest.json'
-          rm manifest.json

--- a/README.md
+++ b/README.md
@@ -303,6 +303,25 @@ We also auto deploy some development branches:
 - [abdo-dev.staging.kitspace.dev](https://abdo-dev.staging.kitspace.dev) (from [abdo-dev](https://github.com/kitspace/kitspace-v2/tree/abdo-dev), [@AbdulrhmnGhanem](https://github.com/AbdulrhmnGhanem)'s branch)
 - [kaspar-dev.staging.kitspace.dev](https://abdo-dev.staging.kitspace.dev) (from [kaspar-dev](https://github.com/kitspace/kitspace-v2/tree/kaspar-dev), [@kasbah](https://github.com/kasbah)'s branch)
 
+### Docker Image Tags
+
+When you notice issues in CI e2e or staging which you can't reproduce with the dev version then you can put something like this in .env:
+
+```
+FRONTEND_DEPLOY_IMAGE_TAG=:kaspar-dev
+PROCESSOR_DEPLOY_IMAGE_TAG=:kaspar-dev
+NGINX_DEPLOY_IMAGE_TAG=:kaspar-dev
+GITEA_DEPLOY_IMAGE_TAG=:kaspar-dev
+```
+
+and 
+
+```
+docker-compose -f docker-compose.yml -f docker-compose.deploy.yml -f docker-compose.e2e.yml
+```
+
+to  try and reproduce the issue locally. 
+
 ## Ansible
 
 We configure our staging servers using [Ansible](https://docs.ansible.com/ansible/latest/index.html). Our playbooks and roles are in the [ansible](ansible/) directory.


### PR DESCRIPTION
I think this is clearer and more useful than having a `latest` tag. When you notice issues in CI e2e or staging which you can't reproduce with the dev version then you can do something like this in .env:

```
FRONTEND_DEPLOY_IMAGE_TAG=:kaspar-dev
PROCESSOR_DEPLOY_IMAGE_TAG=:kaspar-dev
NGINX_DEPLOY_IMAGE_TAG=:kaspar-dev
GITEA_DEPLOY_IMAGE_TAG=:kaspar-dev
```

and 

```
docker-compose -f docker-compose.yml -f docker-compose.deploy.yml -f docker-compose.e2e.yml
```
To reproduce locally. 