### PR TITLE
Delete processor intermediate files

### DIFF
--- a/processor/src/tasks/processGerbers/index.ts
+++ b/processor/src/tasks/processGerbers/index.ts
@@ -223,9 +223,8 @@ export default async function processGerbers(
       job.updateProgress({ status: 'failed', file, error, outputDir })
     }
   }
-  await Promise.all(
-    filePaths.concat(plottedGerbers.gerbers).map(fp => fs.rm(fp, { force: true })),
-  )
+
+  await Promise.all(filePaths.map(fp => fs.rm(fp, { force: true })))
 }
 
 async function generateTopLargePng(topSvgPath, stackup, topLargePngPath) {

--- a/processor/src/tasks/processGerbers/index.ts
+++ b/processor/src/tasks/processGerbers/index.ts
@@ -1,7 +1,7 @@
 import globule from 'globule'
 import Jszip from 'jszip'
+import fs from 'node:fs/promises'
 import path from 'node:path'
-import { promises as fs } from 'node:fs'
 import { Job, JobData } from '../../job.js'
 import * as s3 from '../../s3.js'
 import { exec, execEscaped } from '../../utils.js'
@@ -223,6 +223,8 @@ export default async function processGerbers(
       job.updateProgress({ status: 'failed', file, error, outputDir })
     }
   }
+
+  await Promise.all(filePaths.map(fp => fs.rm(fp, { force: true })))
 }
 
 async function generateTopLargePng(topSvgPath, stackup, topLargePngPath) {
@@ -234,7 +236,7 @@ async function generateTopLargePng(topSvgPath, stackup, topLargePngPath) {
     cmd_large += ` --export-height=${180 * 3 - 128}`
   }
   await exec(cmd_large)
-  return s3.uploadFile(topLargePngPath, 'image/png')
+  await s3.uploadFile(topLargePngPath, 'image/png')
 }
 
 async function generateTopPng(topSvgPath, stackup, topPngPath) {

--- a/processor/src/tasks/processGerbers/index.ts
+++ b/processor/src/tasks/processGerbers/index.ts
@@ -223,8 +223,9 @@ export default async function processGerbers(
       job.updateProgress({ status: 'failed', file, error, outputDir })
     }
   }
-
-  await Promise.all(filePaths.map(fp => fs.rm(fp, { force: true })))
+  await Promise.all(
+    filePaths.concat(plottedGerbers.gerbers).map(fp => fs.rm(fp, { force: true })),
+  )
 }
 
 async function generateTopLargePng(topSvgPath, stackup, topLargePngPath) {

--- a/processor/src/tasks/processGerbers/index.ts
+++ b/processor/src/tasks/processGerbers/index.ts
@@ -63,6 +63,8 @@ export default async function processGerbers(
     topWithBgndPath,
   ]
 
+  const topMetaPngPath = path.join(outputDir, 'images/top-meta.png')
+
   for (const file of filePaths) {
     job.updateProgress({ status: 'in_progress', file, outputDir })
   }
@@ -201,7 +203,6 @@ export default async function processGerbers(
         }),
       )
 
-    const topMetaPngPath = path.join(outputDir, 'images/top-meta.png')
     await generateTopMetaPng(topSvgPath, stackup, topMetaPngPath)
 
     await generateTopWithBgnd(topMetaPngPath, topWithBgndPath)
@@ -224,7 +225,9 @@ export default async function processGerbers(
     }
   }
 
-  await Promise.all(filePaths.map(fp => fs.rm(fp, { force: true })))
+  await Promise.all(
+    [...filePaths, topMetaPngPath].map(fp => fs.rm(fp, { force: true })),
+  )
 }
 
 async function generateTopLargePng(topSvgPath, stackup, topLargePngPath) {

--- a/processor/src/tasks/processIBOM/index.ts
+++ b/processor/src/tasks/processIBOM/index.ts
@@ -1,8 +1,8 @@
 import globule from 'globule'
 import loglevel from 'loglevel'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 import url from 'node:url'
-import { promises as fs } from 'fs'
 import { Job, JobData } from '../../job.js'
 import * as s3 from '../../s3.js'
 import { execEscaped } from '../../utils.js'
@@ -89,6 +89,7 @@ async function processIBOM(
         outputDir,
       }),
     )
+  await fs.rm(ibomOutputPath, {force: true})
 }
 
 async function findBoardFile(folderPath, ext, check?) {

--- a/processor/src/tasks/processIBOM/index.ts
+++ b/processor/src/tasks/processIBOM/index.ts
@@ -89,7 +89,7 @@ async function processIBOM(
         outputDir,
       }),
     )
-  await fs.rm(ibomOutputPath, {force: true})
+  await fs.rm(ibomOutputPath, { force: true })
 }
 
 async function findBoardFile(folderPath, ext, check?) {

--- a/processor/src/tasks/processKicadPCB/index.ts
+++ b/processor/src/tasks/processKicadPCB/index.ts
@@ -8,9 +8,18 @@ import { execEscaped, findKicadPcbFile } from '../../utils.js'
 
 export const outputFiles = ['images/layout.svg'] as const
 
+export interface ProcessKicadPcbData {
+  tmpDir: string
+}
+
 async function processKicadPCB(
   job: Job,
-  { inputDir, kitspaceYaml = {}, outputDir }: Partial<JobData>,
+  {
+    inputDir,
+    kitspaceYaml = {},
+    outputDir,
+    tmpDir,
+  }: ProcessKicadPcbData & Partial<JobData>,
 ) {
   const layoutSvgPath = path.join(outputDir, 'images/layout.svg')
 
@@ -41,7 +50,7 @@ async function processKicadPCB(
       return { inputFiles: {}, gerbers: [] }
     }
 
-    const layoutPromise = plotKicadLayoutSvg(outputDir, layoutSvgPath, kicadPcbFile)
+    const layoutPromise = plotKicadLayoutSvg(layoutSvgPath, kicadPcbFile, tmpDir)
       .then(() =>
         job.updateProgress({ status: 'done', file: layoutSvgPath, outputDir }),
       )
@@ -57,7 +66,7 @@ async function processKicadPCB(
     // Only plot gerbers if there's no `gerbers` key in kitspace.yaml.
     let gerbers = []
     if (kitspaceYaml.gerbers == null) {
-      gerbers = await plotKicadGerbers(outputDir, kicadPcbFile)
+      gerbers = await plotKicadGerbers(kicadPcbFile, tmpDir)
     }
 
     await layoutPromise
@@ -78,28 +87,26 @@ async function processKicadPCB(
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
 const plot_kicad_pcb = path.join(__dirname, 'plot_kicad_pcb')
 
-async function plotKicadGerbers(outputDir, kicadPcbFile) {
-  const tempGerberFolder = path.join('/tmp/kitspace', outputDir, 'gerbers')
-  await execEscaped(['rm', '-rf', tempGerberFolder])
-  await execEscaped(['mkdir', '-p', tempGerberFolder])
-  const plotCommand = [plot_kicad_pcb, 'gerber', kicadPcbFile, tempGerberFolder]
+async function plotKicadGerbers(kicadPcbFile, tmpDir) {
+  const tmpGerberFolder = path.join(tmpDir, 'gerbers')
+  await fs.mkdir(tmpGerberFolder)
+  const plotCommand = [plot_kicad_pcb, 'gerber', kicadPcbFile, tmpGerberFolder]
   await execEscaped(plotCommand)
-  return globule.find(path.join(tempGerberFolder, '*'))
+  return globule.find(path.join(tmpGerberFolder, '*'))
 }
 
 async function plotKicadLayoutSvg(
-  outputDir: string,
   layoutSvgPath: string,
   kicadPcbFile: string,
+  tmpDir: string,
 ) {
-  const tempFolder = path.join('/tmp/kitspace', outputDir, 'svg')
-  await execEscaped(['rm', '-rf', tempFolder])
-  await execEscaped(['mkdir', '-p', tempFolder])
+  const tmpSvgFolder = path.join(tmpDir, 'svg')
+  await fs.mkdir(tmpSvgFolder)
   const plotCommand = [
     plot_kicad_pcb,
     'svg',
     kicadPcbFile,
-    tempFolder,
+    tmpSvgFolder,
     layoutSvgPath,
   ]
   await execEscaped(plotCommand)

--- a/processor/src/tasks/processKicadPCB/index.ts
+++ b/processor/src/tasks/processKicadPCB/index.ts
@@ -1,7 +1,8 @@
 import globule from 'globule'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 import url from 'node:url'
-import { JobData, Job } from '../../job.js'
+import { Job, JobData } from '../../job.js'
 import * as s3 from '../../s3.js'
 import { execEscaped, findKicadPcbFile } from '../../utils.js'
 
@@ -63,11 +64,13 @@ async function processKicadPCB(
 
     const relativeKicadPcbFile = path.relative(inputDir, kicadPcbFile)
     const inputFiles = { [relativeKicadPcbFile]: { type: 'kicad', side: null } }
+    await fs.rm(layoutSvgPath)
     return { inputFiles, gerbers }
   } catch (error) {
     for (const file of filePaths) {
       job.updateProgress({ status: 'failed', file, error, outputDir })
     }
+    await fs.rm(layoutSvgPath, { force: true })
     return { inputFiles: {}, gerbers: [] }
   }
 }

--- a/processor/src/tasks/processKicadPCB/index.ts
+++ b/processor/src/tasks/processKicadPCB/index.ts
@@ -73,14 +73,14 @@ async function processKicadPCB(
 
     const relativeKicadPcbFile = path.relative(inputDir, kicadPcbFile)
     const inputFiles = { [relativeKicadPcbFile]: { type: 'kicad', side: null } }
-    await fs.rm(layoutSvgPath)
     return { inputFiles, gerbers }
   } catch (error) {
     for (const file of filePaths) {
       job.updateProgress({ status: 'failed', file, error, outputDir })
     }
-    await fs.rm(layoutSvgPath, { force: true })
     return { inputFiles: {}, gerbers: [] }
+  } finally {
+    await fs.rm(layoutSvgPath, { force: true })
   }
 }
 

--- a/processor/src/tasks/processPCB.ts
+++ b/processor/src/tasks/processPCB.ts
@@ -1,3 +1,5 @@
+import path from 'node:path'
+import fs from 'node:fs/promises'
 import { Job, JobData } from '../job.js'
 import processGerbers, {
   outputFiles as gerberFiles,
@@ -9,6 +11,12 @@ import processKicadPCB, {
 export const outputFiles = [...gerberFiles, ...kicadFiles] as const
 
 export default async function processPCB(job: Job, jobData: JobData) {
-  const plottedGerbers = await processKicadPCB(job, jobData)
-  await processGerbers(job, { ...jobData, plottedGerbers })
+  const tmpDir = path.join('/tmp/kitspace', jobData.outputDir)
+  await fs.mkdir(tmpDir, { recursive: true })
+  try {
+    const plottedGerbers = await processKicadPCB(job, { tmpDir, ...jobData })
+    await processGerbers(job, { ...jobData, plottedGerbers })
+  } finally {
+    await fs.rm(tmpDir, { force: true, recursive: true })
+  }
 }


### PR DESCRIPTION
Removes all the temp files and those that get uploaded to s3. Just deleting everything at the end of the processing would have been easier but I decided to keep the removal of files as close as possible to the creation of the files. I think it makes more sense this way because it decouples the tasks from the rest of the app. 