### PR TITLE
Fix e2e test for readme images

### DIFF
--- a/e2e/cypress/integration/IBOM.spec.js
+++ b/e2e/cypress/integration/IBOM.spec.js
@@ -63,7 +63,7 @@ describe('IBOM page', () => {
     /* Migrate the normal repo */
     cy.forceVisit('/projects/new')
 
-    const syncedRepoUrl = 'https://github.com/kitspace-forks/CH330_Hardware'
+    const syncedRepoUrl = 'https://github.com/kitspace-test-repos/CH330_Hardware'
     const normalRepoName = 'CH330_Hardware'
 
     cy.get('[data-cy=sync-field]').type(syncedRepoUrl)

--- a/e2e/cypress/integration/readme.spec.js
+++ b/e2e/cypress/integration/readme.spec.js
@@ -9,11 +9,12 @@ describe('Relative README images URLs normalization', () => {
     cy.visit('/')
   })
 
-  it('should be able to fetch relative README image', () => {
+  it('handles readme images starting with `/`', () => {
     const { username, email, password } = getFakeUser()
 
     const repoName = 'CH330_Hardware'
-    const syncedRepoUrl = 'https://github.com/kitspace-test-repos/CH330_Hardware'
+    const syncedRepoUrl =
+      'https://github.com/kitspace-test-repos/CH330_Hardware'
 
     cy.createUser(username, email, password)
     cy.visit('/')
@@ -28,14 +29,14 @@ describe('Relative README images URLs normalization', () => {
     // Wait for redirection for project page
     cy.url({ timeout: 60_000 }).should('contain', `${username}/${repoName}`)
 
-    cy.get('[data-cy=relative-readme-img]', { timeout: 60_000 })
+    cy.get('[data-cy=readme-img]', { timeout: 60_000 })
       .should('have.attr', 'src')
       .then(src =>
         fetch(src).then(res => {
           assert(res.ok, 'expected "ok" http response when requesting image')
           assert(
-            res.headers.get('content-type') === 'image/png',
-            'expected http response to have content-type image/png',
+            res.headers.get('content-type').startsWith('image/'),
+            'expected http response to have content-type image/*',
           )
         }),
       )

--- a/e2e/cypress/integration/readme.spec.js
+++ b/e2e/cypress/integration/readme.spec.js
@@ -30,15 +30,15 @@ describe('Relative README images URLs normalization', () => {
 
     cy.get('[data-cy=relative-readme-img]', { timeout: 60_000 })
       .should('have.attr', 'src')
-      .then(src => {
+      .then(src =>
         fetch(src).then(res => {
           assert(res.ok, 'expected "ok" http response when requesting image')
           assert(
             res.headers.get('content-type') === 'image/png',
             'expected http response to have content-type image/png',
           )
-        })
-      })
+        }),
+      )
   })
 
   it('handles readmes in folders', () => {

--- a/processor/src/tasks/processReadme/urlTransformer.ts
+++ b/processor/src/tasks/processReadme/urlTransformer.ts
@@ -67,7 +67,7 @@ function urlTransformer({
             SrcModifier({ readmeFolder, ownerName, repoName, defaultBranch }),
           )
           node.properties.loading = 'lazy'
-          node.properties['data-cy'] = 'relative-readme-img'
+          node.properties['data-cy'] = 'readme-img'
           break
         default:
           break


### PR DESCRIPTION
I'm not totally sure what this test was supposed to be testing for since the test and `data-cy` talked about "relative" images but two of them were remote images and the other two were in the repo, so I dunno, "relative" to what? The main problem though is the remote images are private now so I've updated the test repo. 

Also, I should probably add floating promise eslint to e2e and frontend (the promise was floating and hence the assert wasn't in the test from cypress perspective, it still failed the test when it should but the error message was a bit more confusing than it needed to be). 

Fixes https://github.com/kitspace/kitspace-v2/issues/479 