### PR TITLE
Replace `execEscaped` with a template tag

### DIFF
--- a/processor/package.json
+++ b/processor/package.json
@@ -48,7 +48,6 @@
     "remark-gfm": "^3.0.1",
     "remark-parse": "^10.0.1",
     "remark-rehype": "^10.1.0",
-    "shell-escape": "^0.2.0",
     "superagent": "^6.1.0",
     "unified": "^10.1.2",
     "unist-util-visit": "^4.1.1",

--- a/processor/src/shell.ts
+++ b/processor/src/shell.ts
@@ -1,0 +1,44 @@
+import cp from 'node:child_process'
+import util from 'node:util'
+
+const exec = util.promisify(cp.exec)
+
+export interface ExecReturn {
+  stdout: string
+  stderr: string
+}
+
+/*
+ * Tagged template that escapes inputs and executes via the shell
+ * example: sh`echo ${userName}`
+ */
+export async function sh(
+  strings: TemplateStringsArray,
+  ...values: Array<unknown>
+): Promise<ExecReturn> {
+  const escaped = values.map(String).map(shellEscape)
+  const cmd = recombineTemplate(strings, escaped)
+  return exec(cmd)
+}
+
+// adapted from https://github.com/xxorax/node-shell-escape
+function shellEscape(s: string): string {
+  if (/[^A-Za-z0-9_\/:=-]/.test(s)) {
+    s = "'" + s.replace(/'/g, "'\\''") + "'"
+    // unduplicate single-quote at the beginning
+    s = s
+      .replace(/^(?:'')+/g, '')
+      // remove non-escaped single-quote if there are enclosed between 2 escaped
+      .replace(/\\'''/g, "\\'")
+  }
+  return s
+}
+
+function recombineTemplate(
+  strings: TemplateStringsArray,
+  values: Array<string>,
+): string {
+  return strings.reduce((acc, str, i) => {
+    return `${acc}${str}${values[i] || ''}`
+  }, '')
+}

--- a/processor/src/shell.ts
+++ b/processor/src/shell.ts
@@ -23,8 +23,8 @@ export async function sh(
 
 // adapted from https://github.com/xxorax/node-shell-escape
 function shellEscape(s: string): string {
-  if (/[^A-Za-z0-9_\/:=-]/.test(s)) {
-    s = "'" + s.replace(/'/g, "'\\''") + "'"
+  if (/[^A-Za-z0-9_/:=-]/.test(s)) {
+    s = `'${s.replace(/'/g, "'\\''")}'`
     // unduplicate single-quote at the beginning
     s = s
       .replace(/^(?:'')+/g, '')

--- a/processor/src/tasks/processGerbers/index.ts
+++ b/processor/src/tasks/processGerbers/index.ts
@@ -231,24 +231,24 @@ export default async function processGerbers(
 }
 
 async function generateTopLargePng(topSvgPath, stackup, topLargePngPath) {
-  let exportWidth: number
+  let constraint: string
   if (stackup.top.width > stackup.top.height + 0.05) {
-    exportWidth = 240 * 3 - 128
+    constraint = `--export-width=${240 * 3 - 128}`
   } else {
-    exportWidth = 180 * 3 - 128
+    constraint = `--export-height=${180 * 3 - 128}`
   }
-  await sh`inkscape --without-gui ${topSvgPath} --export-width=${exportWidth} --export-png=${topLargePngPath}`
+  await sh`inkscape --without-gui ${topSvgPath} ${constraint} --export-png=${topLargePngPath}`
   await s3.uploadFile(topLargePngPath, 'image/png')
 }
 
 async function generateTopPng(topSvgPath, stackup, topPngPath) {
-  let exportWidth: number
+  let constraint: string
   if (stackup.top.width > stackup.top.height + 0.05) {
-    exportWidth = 240
+    constraint = `--export-width=${240}`
   } else {
-    exportWidth = 180
+    constraint = `--export-height=${180}`
   }
-  await sh`inkscape --without-gui ${topSvgPath} --export-width=${exportWidth} --export-png=${topPngPath}`
+  await sh`inkscape --without-gui ${topSvgPath} ${constraint} --export-png=${topPngPath}`
   return s3.uploadFile(topPngPath, 'image/png')
 }
 

--- a/processor/src/tasks/processGerbers/index.ts
+++ b/processor/src/tasks/processGerbers/index.ts
@@ -4,7 +4,7 @@ import fs from 'node:fs/promises'
 import path from 'node:path'
 import { Job, JobData } from '../../job.js'
 import * as s3 from '../../s3.js'
-import { exec, execEscaped } from '../../utils.js'
+import { sh } from '../../shell.js'
 import boardBuilder from './board_builder.js'
 import findGerberFiles from './findGerberFiles.js'
 
@@ -77,7 +77,7 @@ export default async function processGerbers(
   }
 
   try {
-    await execEscaped(['mkdir', '-p', path.join(outputDir, 'images')])
+    await fs.mkdir(path.join(outputDir, 'images'), { recursive: true })
 
     let inputFiles: PlottedGerbers['inputFiles']
     let gerbers: PlottedGerbers['gerbers']
@@ -231,51 +231,47 @@ export default async function processGerbers(
 }
 
 async function generateTopLargePng(topSvgPath, stackup, topLargePngPath) {
-  let cmd_large = `inkscape --without-gui '${topSvgPath}'`
-  cmd_large += ` --export-png='${topLargePngPath}'`
+  let exportWidth: number
   if (stackup.top.width > stackup.top.height + 0.05) {
-    cmd_large += ` --export-width=${240 * 3 - 128}`
+    exportWidth = 240 * 3 - 128
   } else {
-    cmd_large += ` --export-height=${180 * 3 - 128}`
+    exportWidth = 180 * 3 - 128
   }
-  await exec(cmd_large)
+  await sh`inkscape --without-gui ${topSvgPath} --export-width=${exportWidth} --export-png=${topLargePngPath}`
   await s3.uploadFile(topLargePngPath, 'image/png')
 }
 
 async function generateTopPng(topSvgPath, stackup, topPngPath) {
-  let cmd = `inkscape --without-gui '${topSvgPath}'`
-  cmd += ` --export-png='${topPngPath}'`
+  let exportWidth: number
   if (stackup.top.width > stackup.top.height + 0.05) {
-    cmd += ' --export-width=240'
+    exportWidth = 240
   } else {
-    cmd += ' --export-height=180'
+    exportWidth = 180
   }
-  await exec(cmd)
+  await sh`inkscape --without-gui ${topSvgPath} --export-width=${exportWidth} --export-png=${topPngPath}`
   return s3.uploadFile(topPngPath, 'image/png')
 }
 
-function generateTopMetaPng(topSvgPath, stackup, topMetaPngPath) {
-  let cmd_meta = `inkscape --without-gui '${topSvgPath}'`
-  cmd_meta += ` --export-png='${topMetaPngPath}'`
+async function generateTopMetaPng(topSvgPath, stackup, topMetaPngPath) {
   const width = 900
   let height = 400
   const ratioW = width / stackup.top.width
-  if (ratioW * stackup.top.height > height) {
+  const isWide = ratioW * stackup.top.height > height
+  if (isWide) {
     let ratioH = height / stackup.top.height
     while (ratioH * stackup.top.width > width) {
       height -= 1
       ratioH = height / stackup.top.height
     }
-    cmd_meta += ` --export-height=${height}`
-  } else {
-    cmd_meta += ` --export-width=${width}`
   }
-  return exec(cmd_meta)
+  const constraint = isWide
+    ? `--export-height=${height}`
+    : `--export-width=${width}`
+  await sh`inkscape --without-gui ${topSvgPath} ${constraint} --export-png=${topMetaPngPath}`
 }
 
 async function generateTopWithBgnd(topMetaPngPath, topWithBgndPath) {
-  const cmd = `convert -background '#373737' -gravity center '${topMetaPngPath}' -extent 1000x524 '${topWithBgndPath}'`
-  await exec(cmd)
+  await sh`convert -background '#373737' -gravity center ${topMetaPngPath} -extent 1000x524 ${topWithBgndPath}`
   return s3.uploadFile(topWithBgndPath, 'image/png')
 }
 

--- a/processor/src/tasks/processIBOM/index.ts
+++ b/processor/src/tasks/processIBOM/index.ts
@@ -64,8 +64,7 @@ async function processIBOM(
   const ibomOutputFolder = path.dirname(ibomOutputPath)
   await fs.mkdir(ibomOutputFolder, { recursive: true })
 
-  // !note: we can't escape empty `summary` so we have to quote it manually.
-  const summary = kitspaceYaml.summary || "''"
+  const summary = kitspaceYaml.summary
   const __dirname = path.dirname(url.fileURLToPath(import.meta.url))
   const run_ibom = path.join(__dirname, 'run_ibom')
   const ibomName = subprojectName === '_' ? repoName : subprojectName

--- a/processor/src/tasks/processKicadPCB/index.ts
+++ b/processor/src/tasks/processKicadPCB/index.ts
@@ -4,7 +4,8 @@ import path from 'node:path'
 import url from 'node:url'
 import { Job, JobData } from '../../job.js'
 import * as s3 from '../../s3.js'
-import { execEscaped, findKicadPcbFile } from '../../utils.js'
+import { sh } from '../../shell.js'
+import { findKicadPcbFile } from '../../utils.js'
 
 export const outputFiles = ['images/layout.svg'] as const
 
@@ -90,8 +91,7 @@ const plot_kicad_pcb = path.join(__dirname, 'plot_kicad_pcb')
 async function plotKicadGerbers(kicadPcbFile, tmpDir) {
   const tmpGerberFolder = path.join(tmpDir, 'gerbers')
   await fs.mkdir(tmpGerberFolder)
-  const plotCommand = [plot_kicad_pcb, 'gerber', kicadPcbFile, tmpGerberFolder]
-  await execEscaped(plotCommand)
+  await sh`${plot_kicad_pcb} gerber ${kicadPcbFile} ${tmpGerberFolder}`
   return globule.find(path.join(tmpGerberFolder, '*'))
 }
 
@@ -102,14 +102,7 @@ async function plotKicadLayoutSvg(
 ) {
   const tmpSvgFolder = path.join(tmpDir, 'svg')
   await fs.mkdir(tmpSvgFolder)
-  const plotCommand = [
-    plot_kicad_pcb,
-    'svg',
-    kicadPcbFile,
-    tmpSvgFolder,
-    layoutSvgPath,
-  ]
-  await execEscaped(plotCommand)
+  await sh`${plot_kicad_pcb} svg ${kicadPcbFile} ${tmpSvgFolder} ${layoutSvgPath}`
   await s3.uploadFile(layoutSvgPath, 'image/svg+xml')
 }
 

--- a/processor/src/utils.ts
+++ b/processor/src/utils.ts
@@ -1,14 +1,9 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import util from 'node:util'
-import cp, { ProcessEnvOptions } from 'node:child_process'
-import shellEscape from 'shell-escape'
 
 const accessPromise = util.promisify(fs.access)
 
-export const exec = util.promisify(cp.exec)
-export const execEscaped = (args: string[], options?: ProcessEnvOptions) =>
-  util.promisify(cp.exec)(shellEscape(args), options)
 export const { writeFile } = fs.promises
 export const readFile = util.promisify(fs.readFile)
 

--- a/processor/test/integration/projects.test.ts
+++ b/processor/test/integration/projects.test.ts
@@ -1,21 +1,18 @@
 import { Index, SearchResponse } from 'meilisearch'
 import assert from 'node:assert'
-import cp from 'node:child_process'
 import crypto from 'node:crypto'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import util from 'node:util'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { mock, MockProxy } from 'vitest-mock-extended'
 import { createApp, KitspaceProcessorApp } from '../../src/app.js'
 import { DATA_DIR } from '../../src/env.js'
 import * as giteaDBImported from '../../src/giteaDB.js'
 import * as s3Imported from '../../src/s3.js'
+import { sh } from '../../src/shell.js'
 import { waitFor } from '../../src/utils.js'
 
 const timeout = 120_000
-
-const exec = util.promisify(cp.exec)
 
 const tmpDir = '/data/test/temp/kitspace-processor-test-projects'
 const repoDir = path.join(tmpDir, 'repos')
@@ -95,8 +92,8 @@ describe(
   function () {
     let app: KitspaceProcessorApp
     beforeEach(async function () {
-      await exec(`mkdir -p ${tmpDir}`)
-      await exec(`mkdir -p ${repoDir}`)
+      await sh`mkdir -p ${tmpDir}`
+      await sh`mkdir -p ${repoDir}`
       app = createApp(repoDir)
     })
 
@@ -120,11 +117,12 @@ describe(
         // first we reset HEAD/master to an exact version of the ruler repo
         // so future changes of the repo don't affect this test
         const tmpBare = path.join(tmpDir, 'ruler.git')
-        await exec(`git clone --bare https://github.com/kitspace/ruler ${tmpBare}`)
-        await exec(`cd ${tmpBare} && git update-ref HEAD ${hash}`)
-        await exec(
-          `git clone --bare ${tmpBare} ${path.join(repoDir, 'kitspace/ruler.git')}`,
-        )
+        await sh`git clone --bare https://github.com/kitspace/ruler ${tmpBare}`
+        await sh`cd ${tmpBare} && git update-ref HEAD ${hash}`
+        await sh`git clone --bare ${tmpBare} ${path.join(
+          repoDir,
+          'kitspace/ruler.git',
+        )}`
 
         const files = [
           'kitspace-yaml.json',
@@ -171,16 +169,12 @@ describe(
       // so future changes of the repo don't affect this test
       const hash = '53a7770a66fe0209b38a826d560bc8a4b6b56a0d'
       const tmpBare = path.join(tmpDir, 'diy_particle_detector.git')
-      await exec(
-        `git clone --bare https://github.com/kitspace-forks/DIY_particle_detector ${tmpBare}`,
-      )
-      await exec(`cd ${tmpBare} && git update-ref HEAD ${hash}`)
-      await exec(
-        `git clone --bare ${tmpBare} ${path.join(
-          repoDir,
-          'kitspace-forks/diy_particle_detector.git',
-        )}`,
-      )
+      await sh`git clone --bare https://github.com/kitspace-forks/DIY_particle_detector ${tmpBare}`
+      await sh`cd ${tmpBare} && git update-ref HEAD ${hash}`
+      await sh`git clone --bare ${tmpBare} ${path.join(
+        repoDir,
+        'kitspace-forks/diy_particle_detector.git',
+      )}`
 
       const repoRoot = path.join(
         DATA_DIR,
@@ -229,16 +223,12 @@ describe(
       // so future changes of the repo don't affect this test
       const hash = '3f945920eb3d161d0f6d43a286d1f6ff2a7174d4'
       const tmpBare = path.join(tmpDir, 'tinyogx360.git')
-      await exec(
-        `git clone --bare https://github.com/kitspace-test-repos/tinyogx360 ${tmpBare}`,
-      )
-      await exec(`cd ${tmpBare} && git update-ref HEAD ${hash}`)
-      await exec(
-        `git clone --bare ${tmpBare} ${path.join(
-          repoDir,
-          'kitspace-test-repos/tinyogx360.git',
-        )}`,
-      )
+      await sh`git clone --bare https://github.com/kitspace-test-repos/tinyogx360 ${tmpBare}`
+      await sh`cd ${tmpBare} && git update-ref HEAD ${hash}`
+      await sh`git clone --bare ${tmpBare} ${path.join(
+        repoDir,
+        'kitspace-test-repos/tinyogx360.git',
+      )}`
 
       const files = [
         'kitspace-yaml.json',
@@ -279,16 +269,12 @@ describe(
       // so future changes of the repo don't affect this test
       const hash = 'eacd4ccc160c4ff7cfa9ca5d0047c90ff3f95d42'
       const tmpBare = path.join(tmpDir, 'spaces-in-kitspace-data-paths.git')
-      await exec(
-        `git clone --bare https://github.com/kitspace-test-repos/spaces-in-kitspace-data-paths ${tmpBare}`,
-      )
-      await exec(`cd ${tmpBare} && git update-ref HEAD ${hash}`)
-      await exec(
-        `git clone --bare ${tmpBare} ${path.join(
-          repoDir,
-          'kitspace-test-repos/spaces-in-kitspace-data-paths.git',
-        )}`,
-      )
+      await sh`git clone --bare https://github.com/kitspace-test-repos/spaces-in-kitspace-data-paths ${tmpBare}`
+      await sh`cd ${tmpBare} && git update-ref HEAD ${hash}`
+      await sh`git clone --bare ${tmpBare} ${path.join(
+        repoDir,
+        'kitspace-test-repos/spaces-in-kitspace-data-paths.git',
+      )}`
 
       const projectName = 'aux-ps-cs'
       const files = [
@@ -329,16 +315,12 @@ describe(
       // so future changes of the repo don't affect this test
       const hash = '4cb9f9a659b4b68e57fde0d5c2d2930157157c96'
       const tmpBare = path.join(tmpDir, 'kitspace-test-repos/rover.git')
-      await exec(
-        `git clone --bare https://github.com/kitspace-test-repos/rover ${tmpBare}`,
-      )
-      await exec(`cd ${tmpBare} && git update-ref HEAD ${hash}`)
-      await exec(
-        `git clone --bare ${tmpBare} ${path.join(
-          repoDir,
-          'kitspace-test-repos/rover.git',
-        )}`,
-      )
+      await sh`git clone --bare https://github.com/kitspace-test-repos/rover ${tmpBare}`
+      await sh`cd ${tmpBare} && git update-ref HEAD ${hash}`
+      await sh`git clone --bare ${tmpBare} ${path.join(
+        repoDir,
+        'kitspace-test-repos/rover.git',
+      )}`
 
       const projectName = 'open-source-rover-shield'
 
@@ -358,7 +340,7 @@ describe(
 
     afterEach(async function () {
       await app.stop()
-      await exec(`rm -rf ${tmpDir}`)
+      await sh`rm -rf ${tmpDir}`
       vi.clearAllMocks()
     }, timeout)
   },

--- a/processor/yarn.lock
+++ b/processor/yarn.lock
@@ -4302,11 +4302,6 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
-shell-escape@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/shell-escape/-/shell-escape-0.2.0.tgz#68fd025eb0490b4f567a027f0bf22480b5f84133"
-  integrity sha512-uRRBT2MfEOyxuECseCZd28jC1AJ8hmqqneWQ4VWUTgCAFvb3wKU1jLqj6egC4Exrr88ogg3dp+zroH4wJuaXzw==
-
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"


### PR DESCRIPTION
I just realized template tags are made for this kind of thing. It escapes anything that comes in via a variable. I vendored and modified shell-escape since it's quite a simple function actually. 

closes #465 