### PR TITLE
Handle special characters e2e commit info

### DIFF
--- a/e2e/entrypoint.sh
+++ b/e2e/entrypoint.sh
@@ -6,7 +6,7 @@ if [[ -z $GITHUB_TOKEN ]]; then
     # The tests are running locally.
     npx wait-on http://kitspace.test:3000 && cypress run -b chrome
 else
-    escaped_commit_info=$(python3 -c "import shlex; print(shlex.quote('''$COMMIT_INFO_MESSAGE'''))")
+    escaped_commit_info=$(python3 -c "import shlex; print(shlex.quote('''$COMMIT_INFO_MESSAGE'''.split('\n')[0]))")
     echo $escaped_commit_info
     # The tests are running in CI.
     npx wait-on http://kitspace.test:3000 && cypress run --parallel --record -k $CYPRESS_RECORD_KEY \


### PR DESCRIPTION
I found escaping the commit body may be unnecessarily complicated and we don't need it in the cypress dashboard. So I removed it.
I rebased the depedabot commit on top of this commit to test that [it works](https://github.com/kitspace/kitspace-v2/actions/runs/4140118757).
##
Fixes #548