### PR TITLE
Hide gitea

### DIFF
--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -66,8 +66,17 @@ Cypress.Commands.add('importRepo', (remoteUrl, repoName, user) => {
   cy.createGiteaUser(user).then(giteaUser => {
     cy.mirrorRepo(remoteUrl, repoName, giteaUser)
   })
-  cy.waitForStatusCode(
-    `http://gitea.kitspace.test:3000/${user.username}/${repoName}`,
+
+  cy.waitUntil(
+    () =>
+      cy
+        .request({
+          url: `http://gitea.kitspace.test:3000/api/v1/repos/${user.username}/${repoName}`,
+          method: 'GET',
+          failOnStatusCode: false,
+        })
+        .then(response => response.body.empty !== false),
+    { timeout: 60_000, interval: 1000 },
   )
 })
 

--- a/nginx/kitspace.template
+++ b/nginx/kitspace.template
@@ -4,7 +4,7 @@ server {
 
     server_name @KITSPACE_DOMAIN;
 
-    location /robots.txt {
+    location = /robots.txt {
         add_header Content-Type text/plain;
         return 200 "@KITSPACE_ROBOTS_TXT";
     }
@@ -35,7 +35,7 @@ server {
 
     server_name gitea.@KITSPACE_DOMAIN;
 
-    location /robots.txt {
+    location = /robots.txt {
         add_header Content-Type text/plain;
         return 200 "@KITSPACE_ROBOTS_TXT";
     }
@@ -73,7 +73,7 @@ server {
 
     server_name meilisearch.@KITSPACE_DOMAIN;
 
-    location /robots.txt {
+    location = /robots.txt {
         add_header Content-Type text/plain;
         return 200 "@KITSPACE_ROBOTS_TXT";
     }

--- a/nginx/kitspace.template
+++ b/nginx/kitspace.template
@@ -40,7 +40,9 @@ server {
         return 200 "@KITSPACE_ROBOTS_TXT";
     }
 
-    location ^~ / {
+    # Proxy api, and raw content requests to gitea, otherwise return 404.
+    # The raw content is for readme images.
+    location ~ ^/(api|[^/]+/[^/]+/raw)/ {
         proxy_set_header           Host                               $http_host;
         proxy_set_header           X-Real-IP                          $remote_addr;
         proxy_set_header           X-Forwarded-For                    $proxy_add_x_forwarded_for;
@@ -58,6 +60,10 @@ server {
             return 204;
         }
         proxy_pass http://gitea:3000;
+    }
+
+    location ~ / {
+        return 404;
     }
 }
 

--- a/nginx/reachability_healthcheck
+++ b/nginx/reachability_healthcheck
@@ -12,7 +12,7 @@ healthcheck() {
     # Maeke sure that each service is reachable from external domain.s
     if [ "$KITSPACE_DOMAIN" != "kitspace.test" ]; then
         test_reachability "https://$KITSPACE_DOMAIN" "Kitspace" || report_healthcheck_failure "frontend is unreachable" || reload_nginx
-        test_reachability "https://gitea.$KITSPACE_DOMAIN" "Gitea" || report_healthcheck_failure "gitea is unreachable" || reload_nginx
+        test_reachability "https://gitea.$KITSPACE_DOMAIN/api/v1/settings/ui" "gitea" || report_healthcheck_failure "gitea is unreachable" || reload_nginx
         test_reachability "https://meilisearch.$KITSPACE_DOMAIN" "Meilisearch" || report_healthcheck_failure "meilisearch is unreachable" || reload_nginx
     fi
 }


### PR DESCRIPTION
Proxy api, and raw content requests to gitea, otherwise return 404.
The raw content is for readme images.

Closes #474.
