### PR TITLE
Fix history navigation for search

### DIFF
--- a/frontend/src/contexts/SearchContext.tsx
+++ b/frontend/src/contexts/SearchContext.tsx
@@ -11,6 +11,7 @@ const SearchProvider = ({ children, initialQuery }: SearchProviderProps) => {
 
   const {
     query: { q },
+    events,
   } = useRouter()
 
   useEffect(() => {
@@ -18,6 +19,18 @@ const SearchProvider = ({ children, initialQuery }: SearchProviderProps) => {
       setQuery('')
     }
   }, [q])
+
+  events?.on('routeChangeComplete', (url: string) => {
+    /*
+     * Handle history navigation by update the search query in the context when the url changes.
+     * We read the query parameter from the url instead of using the router query
+     * because the router query gets updated asynchronously.
+     */
+    const latestQuery = new URLSearchParams(url.split('?')[1]).get('q')
+    if (latestQuery != null) {
+      setQuery(latestQuery)
+    }
+  })
 
   return (
     <SearchContext.Provider value={{ query, updateQuery: setQuery }}>


### PR DESCRIPTION
Before this commit using the browser history navigation didn't work for
the search. i.e, if you type a `q1` in the search bar, and submit, then type
`q2` and submit, if you go back using the browser button, the page would
still show the results of `q2` instead of `q1`
