### PR TITLE
Delete the repo if it's already processed

### DIFF
--- a/processor/src/queues.ts
+++ b/processor/src/queues.ts
@@ -15,7 +15,7 @@ import redisConnection from './redisConnection.js'
 
 const defaultJobOptions: bullmq.JobsOptions = {
   // keep completed jobs for an hour
-  // we update progress on jobs asynchonously when the task promise may have already been
+  // we update progress on jobs asynchronously when the task promise may have already been
   // completed so we should never remove completed jobs right away as it will cause errors
   removeOnComplete: { age: 3600 },
   // keep the last 5000 failed jobs
@@ -140,6 +140,9 @@ export async function addProjectToQueues({
 
   if (await alreadyProcessed(outputDir, kitspaceYamlArray, giteaId, hash)) {
     // Early return if the project is already in S3 and indexed
+    fs.rm(inputDir, { recursive: true }).catch(err =>
+      log.error(`failed to clean up ${inputDir}: ${err}`),
+    )
     return
   }
 


### PR DESCRIPTION
Running `importBoartsTxt` on a fresh server (but all repos are already processed)

### before
```
VOLUME NAME                                                        LINKS     SIZE
kitspace-abdo-dev_processor-data                                   1         12.63GB
```

### after pushing this commit

```
VOLUME NAME                                                        LINKS     SIZE
kitspace-abdo-dev_processor-data                                   1         0B
```
##
Fixes #598