### PR TITLE
Set mirror interval to 10 minutes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,9 @@ services:
       - GITEA__database__USER=gitea
       - GITEA__security__INTERNAL_TOKEN=${GITEA_INTERNAL_TOKEN}
       - GITEA__session__PROVIDER=db
+      - GITEA__cron__ENABLED=true
+      - GITEA__cron__RUN_AT_START=true
+      - GITEA__cron__NOTICE_ON_SUCCESS=true
     volumes:
       - gitea-data:/data
       - /etc/timezone:/etc/timezone:ro

--- a/processor/src/log.ts
+++ b/processor/src/log.ts
@@ -4,10 +4,28 @@ const logLevels: ReadonlyArray<string> = ['debug', 'info', 'warn', 'error']
 
 const level = logLevels.indexOf(LOG_LEVEL)
 
+const getTimeString = () => {
+  const now = new Date()
+  const isoString = `[${now.toISOString().split('.')[0]}Z] `
+  return isoString
+}
+
 /* eslint-disable no-console */
 export const log = {
-  debug: level <= 0 ? console.debug : () => {},
-  info: level <= 1 ? console.info : () => {},
-  warn: level <= 2 ? console.warn : () => {},
-  error: level <= 3 ? console.error : () => {},
+  debug:
+    level <= 0
+      ? (...args: Array<unknown>) => console.debug(getTimeString(), ...args)
+      : () => {},
+  info:
+    level <= 1
+      ? (...args: Array<unknown>) => console.info(getTimeString(), ...args)
+      : () => {},
+  warn:
+    level <= 2
+      ? (...args: Array<unknown>) => console.warn(getTimeString(), ...args)
+      : () => {},
+  error:
+    level <= 3
+      ? (...args: Array<unknown>) => console.error(getTimeString(), ...args)
+      : () => {},
 }

--- a/scripts/importBoardsTxt.ts
+++ b/scripts/importBoardsTxt.ts
@@ -138,6 +138,7 @@ async function mirrorRepo(
     uid: user.id,
     repo_name: repoName,
     mirror: true,
+    mirror_interval: "10m",
     wiki: false,
     private: false,
     pull_requests: false,


### PR DESCRIPTION
A sample of the processor logs
```log
[2024-01-19T18:22:54Z]  🚀 Kitspace processor service is running.
[2024-01-19T18:22:54Z]  https://partinfo.kitspace.org/graphql health check passed
[2024-01-19T18:22:54Z]  Acquired sync lock for  /gitea-data/git/repositories/kimitobo/neocococat.git
[2024-01-19T18:22:54Z]  Cloning  /gitea-data/git/repositories/kimitobo/neocococat.git
[2024-01-19T18:22:54Z]  Cloned into /data/checkout/kimitobo/Neocococat
[2024-01-19T18:22:54Z]  Released sync lock for  /gitea-data/git/repositories/kimitobo/neocococat.git
[2024-01-19T18:31:17Z]  Acquired sync lock for  /gitea-data/git/repositories/kimitobo/neocococat.git
[2024-01-19T18:31:17Z]  Cloning  /gitea-data/git/repositories/kimitobo/neocococat.git
[2024-01-19T18:31:17Z]  Cloned into /data/checkout/kimitobo/Neocococat
[2024-01-19T18:31:17Z]  Released sync lock for  /gitea-data/git/repositories/kimitobo/neocococat.git
```