### PR TITLE
Add e2e test for URL search clearing

### DIFF
--- a/e2e/cypress/e2e/search.spec.js
+++ b/e2e/cypress/e2e/search.spec.js
@@ -12,6 +12,23 @@ describe('Search', () => {
     cy.url().should('include', `/search?q=${encodeURIComponent(queryTerm)}`)
   })
 
+  it('should clear URL when search term is deleted', () => {
+    const queryTerm = 'awesome project'
+
+    // Visit homepage
+    cy.visit('/')
+    // Find the search input field
+    cy.get('[data-cy=search-field] > input').as('searchInput')
+    // Type the query term
+    cy.get('@searchInput').type(queryTerm)
+    // Verify the URL includes the search term
+    cy.url().should('include', `/search?q=${encodeURIComponent(queryTerm)}`)
+    // Clear the search input
+    cy.get('@searchInput').clear()
+    // Verify the URL is reset to the base search page or homepage
+    cy.url().should('match', /^https?:\/\/[^/]+\/$/)
+  })
+
   it('should display project card on submitting search form', () => {
     const user = getFakeUser()
 


### PR DESCRIPTION
## Description 🔍

This pull request adds an end-to-end (e2e) test to verify the URL behavior when a search term is cleared. The test ensures that:
- When a search term is typed, the URL updates correctly
- When the search term is deleted, the URL resets to the homepage

## Test Details

- Test Location: cypress/e2e/search.cy.js
- Functionality Tested: URL clearing on search input deletion
- Key Scenarios Covered:
      - Typing a search query updates the URL
      - Clearing the search input resets the URL to the homepage

## Changes

- Added new Cypress test for search URL clearing
- Implemented dynamic URL verification
- Ensured robust URL reset checking

## Motivation

Prevent potential URL inconsistencies and improve user experience by maintaining clean URL state during search interactions.

## Testing Approach

- Uses Cypress for end-to-end testing
- Verifies URL updates dynamically
- Checks URL reset mechanism
