### PR TITLE
Add gimbal-controller-pcb link to boards.txt

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -149,3 +149,4 @@ https://github.com/dtomcat/ArdPromSD
 https://github.com/rbaron/b-parasite
 https://github.com/Ryzee119/hawk
 https://github.com/sgreg/4chord-midi
+https://github.com/mrzhangpcb-a11y/gimbal-controller-pcb


### PR DESCRIPTION
Adding TJHXPCB's gimbal controller PCB project.

- MCU: STM32F765VIT6 (ARM Cortex-M7)
- Features: RS-485 x4, isolated RS-485, RS-232, SPI Flash
- Gerber files and BOM included
- Manufactured by TJHXPCB (https://tjhxpcb.com)
- kitspace.yaml included with site link